### PR TITLE
Disable xdebug PHP ext

### DIFF
--- a/circleci-env-core/Dockerfile
+++ b/circleci-env-core/Dockerfile
@@ -34,6 +34,9 @@ RUN apt-get update \
   # Update PHP configuration.
   && echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-memory.ini \
   \
+  # Disable xdebug PHP extension.
+  && rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  \
   # Update composer to latest version.
   && composer self-update --no-interaction --no-progress \
   \


### PR DESCRIPTION
We do not use xdebug for now. Disabling it will make us save about 40% of total test jobs duration.