### PR TITLE
Ensure pulling lastest state of base images on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
       - run:
           name: "Build docker image"
           command: |
-            docker build -t << parameters.tag >> --build-arg BASE_IMAGE=<< parameters.base_image >> << parameters.path >>
+            docker build --pull --tag << parameters.tag >> --build-arg BASE_IMAGE=<< parameters.base_image >> << parameters.path >>
       - run:
           name: "Push docker image"
           command: |


### PR DESCRIPTION
Adding the `--pull` arg will make docker check if cached base image is up to date.