### PR TITLE
Fix build on Debian Buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,19 +35,19 @@ jobs:
           docker_layer_caching: true
       - build:
           path: "circleci-env-core"
-          base_image: "circleci/php:5.6-fpm-node"
+          base_image: "circleci/php:5.6-fpm-stretch-node"
           tag: "glpi/circleci-env-core:php_5.6_fpm-node"
       - build:
           path: "circleci-env-core"
-          base_image: "circleci/php:7.0-fpm-node"
+          base_image: "circleci/php:7.0-fpm-stretch-node"
           tag: "glpi/circleci-env-core:php_7.0_fpm-node"
       - build:
           path: "circleci-env-core"
-          base_image: "circleci/php:7.1-fpm-node"
+          base_image: "circleci/php:7.1-fpm-stretch-node"
           tag: "glpi/circleci-env-core:php_7.1_fpm-node"
       - build:
           path: "circleci-env-core"
-          base_image: "circleci/php:7.2-fpm-node"
+          base_image: "circleci/php:7.2-fpm-stretch-node"
           tag: "glpi/circleci-env-core:php_7.2_fpm-node"
       - build:
           path: "circleci-env-core"

--- a/circleci-env-core/Dockerfile
+++ b/circleci-env-core/Dockerfile
@@ -9,11 +9,24 @@ RUN \
   # E: Could not open file /var/lib/apt/lists/deb.debian.org_debian_dists_buster_main_binary-amd64_Packages.diff_Index - open (2: No such file or directory)
   rm -rf /var/lib/apt/lists/* \
   \
+  && if [ "$(grep -oP '(?<=^VERSION_CODENAME=).+' /etc/os-release | tr -d '\"')" = "buster" ]; then \
+    # On Buster, install the old freetype6 version to make freetype-config script available
+    # see https://github.com/docker-library/php/issues/865
+    # TODO This may be removed if future PHP versions fixes this
+    echo "\033[0;31m Fallback to old version of freetype6 \033[0m" \
+    && echo "deb http://deb.debian.org/debian stretch main" >> /etc/apt/sources.list.d/stretch.list \
+    && apt-get update && apt-get install --assume-yes --allow-downgrades --no-install-recommends --quiet libfreetype6-dev=2.6.3-3.2 libfreetype6=2.6.3-3.2 \
+    && rm /etc/apt/sources.list.d/stretch.list \
+  ; else \
+    # On Stretch, install the available freetype6 version that contains freetype-config script
+    apt-get update && apt-get install --assume-yes --no-install-recommends --quiet libfreetype6-dev \
+  ; fi \
+  \
   # Update APT sources list
   && apt-get update \
   \
   # Install MySQL client.
-  && apt-get install --assume-yes --no-install-recommends --quiet mysql-client \
+  && apt-get install --assume-yes --no-install-recommends --quiet default-mysql-client \
   \
   # Install mail server and getmail utility.
   && apt-get install --assume-yes --no-install-recommends --quiet dovecot-imapd dovecot-pop3d getmail4 \
@@ -23,7 +36,7 @@ RUN \
   && docker-php-ext-install exif \
   \
   # Install GD PHP extension.
-  && apt-get install --assume-yes --no-install-recommends --quiet libfreetype6-dev libjpeg-dev libpng-dev \
+  && apt-get install --assume-yes --no-install-recommends --quiet libjpeg-dev libpng-dev \
   && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
   && docker-php-ext-install gd \
   \
@@ -44,7 +57,7 @@ RUN \
   \
   # Install APCU PHP extension.
   # apcu-4.0.11 is the fallback version for PHP prior to 7.0
-  && pecl install apcu || pecl install apcu-4.0.11 \
+  && (pecl install apcu || pecl install apcu-4.0.11) \
   && docker-php-ext-enable apcu \
   && echo "apc.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini \
   && echo "apc.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini \


### PR DESCRIPTION
Some CircleCI base images are now build on Debian Buster.

1. Install the old version of `libfreetype6-dev` to be able to compile GD extension (see https://github.com/docker-library/php/issues/865).
2. Install `default-mysql-client` (which was already available on Stretch) instead of  `mysql-client` (which is not available anymore on Buster). It means that we will now use a MariaDB client.