### PR TITLE
Remove obsolete PHP imap extension

### DIFF
--- a/circleci-env-core/Dockerfile
+++ b/circleci-env-core/Dockerfile
@@ -27,11 +27,6 @@ RUN \
   && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
   && docker-php-ext-install gd \
   \
-  # Install imap PHP extension.
-  && apt-get install --assume-yes --no-install-recommends --quiet libc-client-dev libkrb5-dev \
-  && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
-  && docker-php-ext-install imap \
-  \
   # Install mysqli PHP extension (required only for GLPI prior to 10.0).
   && docker-php-ext-install mysqli \
   \

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -24,11 +24,6 @@ RUN \
   && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
   && docker-php-ext-install gd \
   \
-  # Install imap PHP extension.
-  && apk add --update imap-dev krb5-dev libressl-dev \
-  && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
-  && docker-php-ext-install imap \
-  \
   # Install intl PHP extension.
   && apk add --update icu-dev \
   && docker-php-ext-install intl \


### PR DESCRIPTION
Due to https://github.com/glpi-project/glpi/pull/6118, presence of PHP imap extension is useless for CI image.
Removing it will ensure that tests will fails if tests code is using some function shipped by this extension.