### PR TITLE
Add PHP 8.0-dev image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,10 @@ jobs:
           base_image: "php:7.4-rc-fpm-alpine"
           tag: "glpi/githubactions-php:7.4-rc"
       - build:
+          path: "githubactions-php"
+          base_image: "phpdaily/php:8.0.0-dev-fpm-alpine"
+          tag: "glpi/githubactions-php:8.0-dev"
+      - build:
           path: "githubactions-db"
           base_image: "mariadb:10.1"
           tag: "glpi/githubactions-mariadb:10.1"

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -42,6 +42,8 @@ RUN \
   && docker-php-ext-install xmlrpc \
   \
   # Install APCU PHP extension.
+  # pecl is not installed on phpdaily/php:8.0.0-dev-fpm-alpine image
+  && (pecl version || (wget http://pear.php.net/go-pear.phar && php go-pear.phar)) \
   # apcu-4.0.11 is the fallback version for PHP prior to 7.0
   && (pecl install apcu || pecl install apcu-4.0.11) \
   && docker-php-ext-enable apcu \


### PR DESCRIPTION
Image build is OK, but is useless since atoum seems to not work on PHP 8.0.

```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function mageekguy\atoum\includer::errorHandler(), 4 passed and exactly 5 expected in /var/glpi/vendor/atoum/atoum/classes/includer.php:87
Stack trace:
#0 /var/glpi/vendor/atoum/atoum/classes/scripts/runner.php(240): mageekguy\atoum\includer->errorHandler(2, 'include_once(/....', '/var/glpi/vendo...', 240)
#1 /var/glpi/vendor/atoum/atoum/classes/scripts/runner.php(240): include_once()
#2 /var/glpi/vendor/atoum/atoum/classes/includer.php(53): mageekguy\atoum\scripts\runner->mageekguy\atoum\scripts\{closure}('/.atoum.php')
#3 /var/glpi/vendor/atoum/atoum/classes/script/configurable.php(157): mageekguy\atoum\includer->includePath('/.atoum.php', Object(Closure))
#4 /var/glpi/vendor/atoum/atoum/classes/scripts/runner.php(241): mageekguy\atoum\script\configurable->includeConfigFile('/.atoum.php', Object(Closure))
#5 /var/glpi/vendor/atoum/atoum/classes/script/configurable.php(55): mageekguy\atoum\scripts\runner->useConfigFile('/.atoum.php')
#6 /var/glpi/vendor/atoum in /var/glpi/vendor/atoum/atoum/classes/includer.php on line 87
```