### PR TITLE
Add PHP 7.4 final images build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ jobs:
           tag: "glpi/githubactions-php:latest"
       - build:
           path: "githubactions-php"
-          base_image: "php:7.4-rc-fpm-alpine"
-          tag: "glpi/githubactions-php:7.4-rc"
+          base_image: "php:7.4-fpm-alpine"
+          tag: "glpi/githubactions-php:7.4"
       - build:
           path: "githubactions-db"
           base_image: "mariadb:10.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,10 @@ jobs:
           tag: "glpi/circleci-env-core:php_7.3_fpm-node"
       - build:
           path: "circleci-env-core"
+          base_image: "circleci/php:7.4-fpm-node"
+          tag: "glpi/circleci-env-core:php_7.4_fpm-node"
+      - build:
+          path: "circleci-env-core"
           base_image: "circleci/php:latest-node"
           tag: "glpi/circleci-env-core:php_latest_fpm-node"
   build_all_githubactions_images:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,10 @@ commands:
     parameters:
       path:
         type: string
-        default: "circleci-env-core"
       base_image:
         type: string
-        default: "circleci/php:latest-node"
       tag:
         type: string
-        default: "glpi/circleci-env-core:php_latest_fpm-node"
     steps:
       - run:
           name: "Build docker image"
@@ -56,10 +53,6 @@ jobs:
           path: "circleci-env-core"
           base_image: "circleci/php:7.4-fpm-node"
           tag: "glpi/circleci-env-core:php_7.4_fpm-node"
-      - build:
-          path: "circleci-env-core"
-          base_image: "circleci/php:latest-node"
-          tag: "glpi/circleci-env-core:php_latest_fpm-node"
   build_all_githubactions_images:
     docker:
       - image: docker:18-git


### PR DESCRIPTION
1. Switch from RC to final version of PHP 7.4 for Github Actions images
2. Replace PHP latest by PHP 7.4 for CircleCI images.
