### PR TITLE
Build and push Github actions PHP images

### DIFF
--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -1,0 +1,33 @@
+name: "Github actions DB images"
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+      - "githubactions-db/**"
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        db:
+          - "mariadb:10.1"
+          - "mariadb:10.2"
+          - "mariadb:10.3"
+          - "mariadb:10.4"
+          - "mysql:5.6"
+          - "mysql:5.7"
+          - "mysql:8.0"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Build image"
+        run: |
+          docker build --pull --tag glpi/githubactions-${{ matrix.db }} --build-arg BASE_IMAGE=${{ matrix.db }} githubactions-db
+      - name: "Push image to Github registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          docker push docker.pkg.github.com/${{ github.repository }}/githubactions-${{ matrix.db }}

--- a/.github/workflows/githubactions-dovecot.yml
+++ b/.github/workflows/githubactions-dovecot.yml
@@ -1,0 +1,22 @@
+name: "Github actions Dovecot image"
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+      - "githubactions-dovecot/**"
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Build image"
+        run: |
+          docker build --pull --tag glpi/githubactions-dovecot:latest --build-arg BASE_IMAGE=debian:buster-slim githubactions-dovecot
+      - name: "Push image to Github registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          docker push docker.pkg.github.com/${{ github.repository }}/githubactions-dovecot:latest

--- a/.github/workflows/githubactions-openldap.yml
+++ b/.github/workflows/githubactions-openldap.yml
@@ -1,0 +1,22 @@
+name: "Github actions Open LDAP image"
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+      - "githubactions-openldap/**"
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Build image"
+        run: |
+          docker build --pull --tag glpi/githubactions-openldap:latest --build-arg BASE_IMAGE=alpine githubactions-openldap
+      - name: "Push image to Github registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          docker push docker.pkg.github.com/${{ github.repository }}/githubactions-openldap:latest

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -1,0 +1,32 @@
+name: "Github actions PHP images"
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+      - "githubactions-php/**"
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "5.6"
+          - "7.0"
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Build image"
+        run: |
+          docker build --pull --tag glpi/githubactions-php:${{ matrix.php-version }} --build-arg BASE_IMAGE=php:${{ matrix.php-version }}-fpm-alpine githubactions-php
+      - name: "Push image to Github registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          docker push docker.pkg.github.com/${{ github.repository }}/githubactions-php:${{ matrix.php-version }}


### PR DESCRIPTION
Add Github actions workflows to build and push, into Github docker repository, images used by `glpi-project/glpi` CI actions.