### PR TITLE
Build images used by Github Actions by Github Actions itself

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,83 +53,12 @@ jobs:
           path: "circleci-env-core"
           base_image: "circleci/php:7.4-fpm-node"
           tag: "glpi/circleci-env-core:php_7.4_fpm-node"
-  build_all_githubactions_images:
-    docker:
-      - image: docker:18-git
-    steps:
-      - checkout
-      - setup_remote_docker
-      - build:
-          path: "githubactions-php"
-          base_image: "php:5.6-fpm-alpine"
-          tag: "glpi/githubactions-php:5.6"
-      - build:
-          path: "githubactions-php"
-          base_image: "php:7.0-fpm-alpine"
-          tag: "glpi/githubactions-php:7.0"
-      - build:
-          path: "githubactions-php"
-          base_image: "php:7.1-fpm-alpine"
-          tag: "glpi/githubactions-php:7.1"
-      - build:
-          path: "githubactions-php"
-          base_image: "php:7.2-fpm-alpine"
-          tag: "glpi/githubactions-php:7.2"
-      - build:
-          path: "githubactions-php"
-          base_image: "php:7.3-fpm-alpine"
-          tag: "glpi/githubactions-php:7.3"
-      - build:
-          path: "githubactions-php"
-          base_image: "php:7.3-fpm-alpine"
-          tag: "glpi/githubactions-php:latest"
-      - build:
-          path: "githubactions-php"
-          base_image: "php:7.4-fpm-alpine"
-          tag: "glpi/githubactions-php:7.4"
-      - build:
-          path: "githubactions-db"
-          base_image: "mariadb:10.1"
-          tag: "glpi/githubactions-mariadb:10.1"
-      - build:
-          path: "githubactions-db"
-          base_image: "mariadb:10.2"
-          tag: "glpi/githubactions-mariadb:10.2"
-      - build:
-          path: "githubactions-db"
-          base_image: "mariadb:10.3"
-          tag: "glpi/githubactions-mariadb:10.3"
-      - build:
-          path: "githubactions-db"
-          base_image: "mariadb:10.4"
-          tag: "glpi/githubactions-mariadb:10.4"
-      - build:
-          path: "githubactions-db"
-          base_image: "mysql:5.6"
-          tag: "glpi/githubactions-mysql:5.6"
-      - build:
-          path: "githubactions-db"
-          base_image: "mysql:5.7"
-          tag: "glpi/githubactions-mysql:5.7"
-      - build:
-          path: "githubactions-db"
-          base_image: "mysql:8.0"
-          tag: "glpi/githubactions-mysql:8.0"
-      - build:
-          path: "githubactions-dovecot"
-          base_image: "debian:buster-slim"
-          tag: "glpi/githubactions-dovecot:latest"
-      - build:
-          path: "githubactions-openldap"
-          base_image: "alpine"
-          tag: "glpi/githubactions-openldap:latest"
 
 workflows:
   # Build images every time a PR is created or a branch is updated.
   pr_build:
     jobs:
       - build_all_circleci-env-core
-      - build_all_githubactions_images
 
   # Weekly build to be sure to have latest PHP bugfixes in images
   # even if no changes were made on master branch.
@@ -143,4 +72,3 @@ workflows:
                 - master
     jobs:
       - build_all_circleci-env-core
-      - build_all_githubactions_images

--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -26,10 +26,18 @@ jobs:
       - name: "Build image"
         run: |
           docker build --pull --tag image --build-arg BASE_IMAGE=${{ matrix.db }} githubactions-db
-      - name: "Push image to Github registry"
+      - name: "Push image to Docker hub"
         if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-${{ matrix.db }}
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          IMAGE_TAG=glpi/githubactions-${{ matrix.db }}
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
+# We do not use Docker registry for now, do not push images there
+#      - name: "Push image to Github registry"
+#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+#        run: |
+#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-${{ matrix.db }}
+#          docker tag image $IMAGE_TAG
+#          docker push $IMAGE_TAG

--- a/.github/workflows/githubactions-dovecot.yml
+++ b/.github/workflows/githubactions-dovecot.yml
@@ -15,10 +15,18 @@ jobs:
       - name: "Build image"
         run: |
           docker build --pull --tag image --build-arg BASE_IMAGE=debian:buster-slim githubactions-dovecot
-      - name: "Push image to Github registry"
+      - name: "Push image to Docker hub"
         if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-dovecot:latest
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          IMAGE_TAG=glpi/githubactions-dovecot:latest
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
+# We do not use Docker registry for now, do not push images there
+#      - name: "Push image to Github registry"
+#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+#        run: |
+#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-dovecot:latest
+#          docker tag image $IMAGE_TAG
+#          docker push $IMAGE_TAG

--- a/.github/workflows/githubactions-openldap.yml
+++ b/.github/workflows/githubactions-openldap.yml
@@ -15,10 +15,18 @@ jobs:
       - name: "Build image"
         run: |
           docker build --pull --tag image --build-arg BASE_IMAGE=alpine githubactions-openldap
-      - name: "Push image to Github registry"
+      - name: "Push image to Docker hub"
         if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-openldap:latest
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          IMAGE_TAG=glpi/githubactions-openldap:latest
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
+# We do not use Docker registry for now, do not push images there
+#      - name: "Push image to Github registry"
+#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+#        run: |
+#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-openldap:latest
+#          docker tag image $IMAGE_TAG
+#          docker push $IMAGE_TAG

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -25,10 +25,18 @@ jobs:
       - name: "Build image"
         run: |
           docker build --pull --tag image --build-arg BASE_IMAGE=php:${{ matrix.php-version }}-fpm-alpine githubactions-php
-      - name: "Push image to Github registry"
+      - name: "Push image to Docker hub"
         if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-php:${{ matrix.php-version }}
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          IMAGE_TAG=glpi/githubactions-php:${{ matrix.php-version }}
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
+# We do not use Docker registry for now, do not push images there
+#      - name: "Push image to Github registry"
+#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+#        run: |
+#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-php:${{ matrix.php-version }}
+#          docker tag image $IMAGE_TAG
+#          docker push $IMAGE_TAG


### PR DESCRIPTION
Images used by Github Actions were
 - built by CircleCI and pushed do Docker Hub,
 - built by Github Actions and pushed do Github Docker Registry (but not used from there).

Now they will be built only once and pushed only to Docker Hub.