### PR TITLE
Fix override of default system permissions

### DIFF
--- a/circleci-env-core/Dockerfile
+++ b/circleci-env-core/Dockerfile
@@ -66,7 +66,8 @@ RUN \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy files to container.
-COPY ./files /
+COPY ./files/etc/dovecot/local.conf /etc/dovecot/local.conf
+COPY ./files/etc/dovecot/passwd /etc/dovecot/passwd
 
 # Switch back to circleci user
 USER circleci

--- a/githubactions-db/Dockerfile
+++ b/githubactions-db/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=mysql:latest
 
 FROM $BASE_IMAGE
 
-COPY ./files /
+COPY ./files/etc/mysql/conf.d/custom.cnf /etc/mysql/conf.d/custom.cnf
 
 HEALTHCHECK --interval=10s --retries=5 --timeout=5s \
   CMD mysqladmin ping

--- a/githubactions-dovecot/Dockerfile
+++ b/githubactions-dovecot/Dockerfile
@@ -21,7 +21,8 @@ RUN \
   # Clean sources list.
   && rm -rf /var/lib/apt/lists/*
 
-COPY ./files /
+COPY ./files/etc/dovecot/local.conf /etc/dovecot/local.conf
+COPY ./files/etc/dovecot/passwd /etc/dovecot/passwd
 
 HEALTHCHECK --interval=10s --retries=5 --timeout=5s \
   CMD doveadm service status

--- a/githubactions-openldap/Dockerfile
+++ b/githubactions-openldap/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 # Use default config for LDAP database
 RUN mv /var/lib/openldap/openldap-data/DB_CONFIG.example /var/lib/openldap/openldap-data/DB_CONFIG
 
-COPY ./files /
+COPY ./files/etc/openldap/slapd.conf /etc/openldap/slapd.conf
 
 HEALTHCHECK --interval=10s --retries=5 --timeout=5s \
   CMD ldapwhoami  -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure || exit 1


### PR DESCRIPTION
I do not know if it is due to a change on Ubuntu or Docker itself, but since I switched to latest Ubuntu LTS, `COPY` instruction behaviour changed. Indeed, now its overriding existing directory rights to give rights only to the current user defined inside build process.
For instance, `/etc` directory is now only accessible by root user, resulting in lots of permission issues. To prevent this, solution is to copy files one by one.