### PR TITLE
Build MariaDB 10.5 image

### DIFF
--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -17,6 +17,7 @@ jobs:
           - "mariadb:10.2"
           - "mariadb:10.3"
           - "mariadb:10.4"
+          - "mariadb:10.5"
           - "mysql:5.6"
           - "mysql:5.7"
           - "mysql:8.0"


### PR DESCRIPTION
MariaDB is still in beta version, but docker image is already available and we can start testing it.