### PR TITLE
Nightly docker image of GLPI

### DIFF
--- a/.github/workflows/glpi-nightly.yml
+++ b/.github/workflows/glpi-nightly.yml
@@ -1,0 +1,38 @@
+name: "Github actions PHP images"
+
+on:
+  push:
+    paths:
+      - ".github/workflows/glpi-nightly.yml"
+      - "glpi-nightly/**"
+  schedule:
+    - cron:  '0 0 * * 1'
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - "master"
+          - "9.5/bugfixes"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Get sources from glpi-project/glpi"
+        run: |
+          curl https://github.com/glpi-project/glpi/archive/${{ matrix.branch }}.tar.gz --location --output glpi.tar.gz
+          mkdir glpi-nightly/sources
+          tar --extract --ungzip --strip 1 --file glpi.tar.gz --directory glpi-nightly/sources
+      - name: "Build image"
+        run: |
+          docker build --pull --tag image glpi-nightly
+      - name: "Push image to Docker hub"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          IMAGE_VERSION=$(echo ${{ matrix.branch }} | sed -E 's|/|-|')
+          IMAGE_TAG=glpi/glpi-nightly:$IMAGE_VERSION
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+glpi-nightly/sources/

--- a/glpi-nightly/Dockerfile
+++ b/glpi-nightly/Dockerfile
@@ -1,0 +1,121 @@
+#####
+# Builder image
+#####
+FROM php:cli-alpine AS builder
+
+# Copy composer binary from latest composer image.
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Install required system packages.
+RUN \
+  # Install gettext required to compile locales.
+  apk add --update bash \
+  \
+  # Install gettext required to compile locales.
+  && apk add --update gettext \
+  \
+  # Install nodejs and npm.
+  && apk add --update nodejs npm \
+  \
+  # Install git and zip used by composer when fetching dependencies.
+  && apk add --update git unzip \
+  \
+  # Clean sources list.
+  && rm -rf /var/cache/apk/*
+
+ # Update PHP configuration.
+RUN echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-memory.ini
+
+# Copy GLPI source.
+COPY ./sources /usr/src/glpi
+
+# Build GLPI app
+RUN /usr/src/glpi/tools/build_glpi.sh
+
+
+#####
+# Application image
+#####
+FROM php:apache
+
+RUN apt-get update \
+  \
+  # Install APCU PHP extension.
+  && pecl install apcu \
+  && docker-php-ext-enable apcu \
+  && echo "apc.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini \
+  \
+  # Install bz2 PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libbz2-dev \
+  && docker-php-ext-install bz2 \
+  \
+  # Install exif extension.
+  && docker-php-ext-install exif \
+  \
+  # Install gd PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libfreetype6-dev libjpeg-dev libpng-dev \
+  && docker-php-ext-configure gd --with-freetype --with-jpeg \
+  && docker-php-ext-install gd \
+  \
+  # Install intl PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libicu-dev \
+  && docker-php-ext-configure intl \
+  && docker-php-ext-install intl \
+  \
+  # Install ldap PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libldap2-dev \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+  && docker-php-ext-install ldap \
+  \
+  # Install mysqli PHP extension.
+  && docker-php-ext-install mysqli \
+  \
+  # Install soap PHP extension (required for some plugins).
+  && apt-get install --assume-yes --no-install-recommends --quiet libxml2-dev \
+  && docker-php-ext-install soap \
+  \
+  # Install xmlrpc PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libxml2-dev \
+  && docker-php-ext-install xmlrpc \
+  \
+  # Install zip PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libzip-dev \
+  && docker-php-ext-configure zip \
+  && docker-php-ext-install zip \
+  \
+  # Install cron service.
+  && apt-get install --assume-yes --no-install-recommends --quiet cron \
+  \
+  # Install acl to manage acl of writable directories.
+  && apt-get install --assume-yes --no-install-recommends --quiet acl \
+  \
+  # Clean sources list.
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy services configuration files and startup script to container.
+COPY ./files/etc/apache2/sites-available/000-default.conf /etc/apache2/sites-available/000-default.conf
+COPY ./files/etc/cron.d/glpi /etc/cron.d/glpi
+COPY ./files/opt/startup.sh /opt/startup.sh
+
+# Install GLPI crontab.
+RUN crontab -u www-data /etc/cron.d/glpi
+
+# Copy GLPI application.
+COPY --from=builder --chown=www-data:www-data /usr/src/glpi /var/www/glpi
+
+# Declare a volume for "config" and "files" directory
+RUN mkdir /var/glpi && chown www-data:www-data /var/glpi
+VOLUME /var/glpi
+
+# Define GLPI environment variables
+ENV \
+  GLPI_INSTALL_MODE=DOCKER \
+  GLPI_CONFIG_DIR=/var/glpi/config \
+  GLPI_VAR_DIR=/var/glpi/files
+
+# Make startup script executable and executes it as default command.
+RUN chmod u+x /opt/startup.sh
+CMD /opt/startup.sh
+
+# Define application path as base working dir.
+WORKDIR /var/www/glpi

--- a/glpi-nightly/files/etc/apache2/sites-available/000-default.conf
+++ b/glpi-nightly/files/etc/apache2/sites-available/000-default.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/glpi
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    <Directory /var/www/glpi>
+        DirectoryIndex index.php
+        Options FollowSymLinks
+        Require all granted
+    </Directory>
+</VirtualHost>
+

--- a/glpi-nightly/files/etc/cron.d/glpi
+++ b/glpi-nightly/files/etc/cron.d/glpi
@@ -1,0 +1,1 @@
+* * * * *    /usr/local/bin/php /var/www/glpi/front/cron.php &>/dev/null

--- a/glpi-nightly/files/opt/startup.sh
+++ b/glpi-nightly/files/opt/startup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Create config and files volume (sub)directories that are missing
+# and set ACL for www-data user
+dirs=(
+    "/var/glpi/config"
+    "/var/glpi/files"
+    "/var/glpi/files/_cache"
+    "/var/glpi/files/_cron"
+    "/var/glpi/files/_dumps"
+    "/var/glpi/files/_graphs"
+    "/var/glpi/files/_lock"
+    "/var/glpi/files/_log"
+    "/var/glpi/files/_pictures"
+    "/var/glpi/files/_plugins"
+    "/var/glpi/files/_rss"
+    "/var/glpi/files/_sessions"
+    "/var/glpi/files/_tmp"
+    "/var/glpi/files/_uploads"
+)
+for dir in "${dirs[@]}"
+do
+    if [ ! -d "$dir" ]
+    then
+        mkdir "$dir"
+    fi
+    setfacl -m user:www-data:rwx,group:www-data:rwx "$dir"
+done
+
+# Set ACL for www-data user on marketplace directory
+setfacl -m user:www-data:rwx,group:www-data:rwx "/var/www/glpi/marketplace"
+
+# Run cron service.
+cron
+
+# Run command previously defined in base php-apache Dockerfile.
+apache2-foreground
+


### PR DESCRIPTION
Provides a nightly build of GLPI inside a docker image.

Image will be named `glpi/glpi-nightly`.

Port of https://github.com/glpi-project/glpi/pull/7094 outside `glpi-project/glpi` repository.

Example of `docker-compose.yml` file that can be used to run this image.
```yml
version: "3.5"

services:
    glpi:
        container_name: "glpi-9.5-bugfixes"
        image: "glpi/glpi-nightly:9.5-bugfixes"
        ports:
            - "8080:80"
        volumes:
            - "./config:/var/glpi/config"
            - "./files:/var/glpi/files"
            - "./marketplace:/var/www/glpi/marketplace"
    db:
        image: "mysql:5.7"
        restart: "always"
        environment:
            MYSQL_RANDOM_ROOT_PASSWORD: "yes"
            MYSQL_DATABASE: "glpi"
            MYSQL_USER: "glpi"
            MYSQL_PASSWORD: "glpi"
        volumes:
            - "./db:/var/lib/mysql"
```