### PR TITLE
Publish images to ghcr.io (Github container registry)

### DIFF
--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -42,11 +42,10 @@ jobs:
           IMAGE_TAG=glpi/githubactions-${{ matrix.db }}
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
-# We do not use Docker registry for now, do not push images there
-#      - name: "Push image to Github registry"
-#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
-#        run: |
-#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-${{ matrix.db }}
-#          docker tag image $IMAGE_TAG
-#          docker push $IMAGE_TAG
+      - name: "Push image to Github container registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GHCR_ACCESS_TOKEN }}" | docker login -u ${{ secrets.GHCR_USERNAME }} --password-stdin ghcr.io
+          IMAGE_TAG=ghcr.io/glpi-project/githubactions-${{ matrix.db }}
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG

--- a/.github/workflows/githubactions-dovecot.yml
+++ b/.github/workflows/githubactions-dovecot.yml
@@ -30,11 +30,10 @@ jobs:
           IMAGE_TAG=glpi/githubactions-dovecot:latest
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
-# We do not use Docker registry for now, do not push images there
-#      - name: "Push image to Github registry"
-#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
-#        run: |
-#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-dovecot:latest
-#          docker tag image $IMAGE_TAG
-#          docker push $IMAGE_TAG
+      - name: "Push image to Github container registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GHCR_ACCESS_TOKEN }}" | docker login -u ${{ secrets.GHCR_USERNAME }} --password-stdin ghcr.io
+          IMAGE_TAG=ghcr.io/glpi-project/githubactions-dovecot:latest
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG

--- a/.github/workflows/githubactions-openldap.yml
+++ b/.github/workflows/githubactions-openldap.yml
@@ -30,11 +30,10 @@ jobs:
           IMAGE_TAG=glpi/githubactions-openldap:latest
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
-# We do not use Docker registry for now, do not push images there
-#      - name: "Push image to Github registry"
-#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
-#        run: |
-#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-openldap:latest
-#          docker tag image $IMAGE_TAG
-#          docker push $IMAGE_TAG
+      - name: "Push image to Github container registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GHCR_ACCESS_TOKEN }}" | docker login -u ${{ secrets.GHCR_USERNAME }} --password-stdin ghcr.io
+          IMAGE_TAG=ghcr.io/glpi-project/githubactions-openldap:latest
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -41,11 +41,10 @@ jobs:
           IMAGE_TAG=glpi/githubactions-php:${{ matrix.php-version }}
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
-# We do not use Docker registry for now, do not push images there
-#      - name: "Push image to Github registry"
-#        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
-#        run: |
-#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-#          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/githubactions-php:${{ matrix.php-version }}
-#          docker tag image $IMAGE_TAG
-#          docker push $IMAGE_TAG
+      - name: "Push image to Github container registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GHCR_ACCESS_TOKEN }}" | docker login -u ${{ secrets.GHCR_USERNAME }} --password-stdin ghcr.io
+          IMAGE_TAG=ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG

--- a/.github/workflows/glpi-nightly.yml
+++ b/.github/workflows/glpi-nightly.yml
@@ -42,3 +42,11 @@ jobs:
           IMAGE_TAG=glpi/glpi-nightly:$IMAGE_VERSION
           docker tag image $IMAGE_TAG
           docker push $IMAGE_TAG
+      - name: "Push image to Github container registry"
+        if: github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images'
+        run: |
+          echo "${{ secrets.GHCR_ACCESS_TOKEN }}" | docker login -u ${{ secrets.GHCR_USERNAME }} --password-stdin ghcr.io
+          IMAGE_VERSION=$(echo ${{ matrix.branch }} | sed -E 's|/|-|')
+          IMAGE_TAG=ghcr.io/glpi-project/glpi-nightly:$IMAGE_VERSION
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This repository contains build files for docker images available in [GLPI Docker Hub](https://hub.docker.com/u/glpi/).
+This repository contains build files for docker images available in [Github Container Registry](https://github.com/orgs/glpi-project/packages?ecosystem=container).


### PR DESCRIPTION
I propose to keep push to Docker Hub for now, and remove them when we will be sure that everything uses new images.