### PR TITLE
Enable manual build and push

### DIFF
--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -13,6 +13,8 @@ on:
       - "githubactions-db/**"
   schedule:
     - cron:  '0 0 * * 1'
+  # Enable manual run
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/githubactions-dovecot.yml
+++ b/.github/workflows/githubactions-dovecot.yml
@@ -13,6 +13,8 @@ on:
       - "githubactions-dovecot/**"
   schedule:
     - cron:  '0 0 * * 1'
+  # Enable manual run
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/githubactions-openldap.yml
+++ b/.github/workflows/githubactions-openldap.yml
@@ -13,6 +13,8 @@ on:
       - "githubactions-openldap/**"
   schedule:
     - cron:  '0 0 * * 1'
+  # Enable manual run
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -13,6 +13,8 @@ on:
       - "githubactions-php/**"
   schedule:
     - cron:  '0 0 * * 1'
+  # Enable manual run
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/glpi-nightly.yml
+++ b/.github/workflows/glpi-nightly.yml
@@ -13,6 +13,8 @@ on:
       - "glpi-nightly/**"
   schedule:
     - cron:  '0 0 * * 1'
+  # Enable manual run
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
We may sometimes require to rebuild and push images without having to change its specs. For instance, I wanted to rebuild images to switch to composer 2.x, and I have either to build them on my machine, either to push a new commit to master.