### PR TITLE
Drop XML-RPC extension

### DIFF
--- a/glpi-nightly/Dockerfile
+++ b/glpi-nightly/Dockerfile
@@ -81,10 +81,6 @@ RUN apt-get update \
   && apt-get install --assume-yes --no-install-recommends --quiet libxml2-dev \
   && docker-php-ext-install soap \
   \
-  # Install xmlrpc PHP extension.
-  && apt-get install --assume-yes --no-install-recommends --quiet libxml2-dev \
-  && docker-php-ext-install xmlrpc \
-  \
   # Install zip PHP extension.
   && apt-get install --assume-yes --no-install-recommends --quiet libzip-dev \
   && docker-php-ext-configure zip \


### PR DESCRIPTION
Nightly docker image build is broken due to switch to PHP 8.0. As XML-RPC API is now deprecated, dropping XML-RPC extension is the simplier solution to fix the build.