### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/glpi-nightly.yml
+++ b/.github/workflows/glpi-nightly.yml
@@ -18,13 +18,14 @@ on:
 
 jobs:
   build:
+    name: "Build ${{ matrix.branch }} on PHP ${{ matrix.php-version }}"
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        branch:
-          - "master"
-          - "9.5/bugfixes"
+        include:
+          - {php-version: "8.0", branch: "master"}
+          - {php-version: "7.4", branch: "9.5/bugfixes"}
     env:
       # Push only when a new commit is pushed on master on glpi-project/docker-images repository.
       push: ${{ github.ref == 'refs/heads/master' && github.repository == 'glpi-project/docker-images' }}
@@ -39,7 +40,7 @@ jobs:
       - name: "Build image"
         run: |
           echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-          docker build --pull --tag image glpi-nightly
+          docker build --pull --tag image --build-arg BUILDER_IMAGE=php:${{ matrix.php-version }}-cli-alpine --build-arg APP_IMAGE=php:${{ matrix.php-version }}-apache glpi-nightly
       - name: "Push image to Github container registry"
         if: env.push == 'true'
         run: |

--- a/glpi-nightly/Dockerfile
+++ b/glpi-nightly/Dockerfile
@@ -1,7 +1,11 @@
+
+ARG BUILDER_IMAGE=php:cli-alpine
+ARG APP_IMAGE=php:apache
+
 #####
 # Builder image
 #####
-FROM php:cli-alpine AS builder
+FROM $BUILDER_IMAGE AS builder
 
 # Copy composer binary from latest composer image.
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
@@ -14,8 +18,11 @@ RUN \
   # Install bash that is used in for build script.
   && apk add bash \
   \
-  # Install gettext required to compile locales.
-  && apk add gettext \
+  # Install patch utility that may be usefull to patch dependencies.
+  && apk add patch \
+  \
+  # Install gettext and perl required to compile locales.
+  && apk add gettext perl \
   \
   # Install nodejs and npm.
   && apk add nodejs npm \
@@ -39,7 +46,7 @@ RUN /usr/src/glpi/tools/build_glpi.sh
 #####
 # Application image
 #####
-FROM php:apache
+FROM $APP_IMAGE
 
 LABEL \
   org.opencontainers.image.title="GLPI nightly build" \


### PR DESCRIPTION
Some nightly build operations were not done but it was not blocking until https://github.com/glpi-project/glpi/pull/8841.

1. perl was not available, so locales were not recompiled.
2. patch utility was not available, so dependencies were not patched.
3. build was done on latest PHP, so robo commands (minification) were failing on 9.5/bugfixes branch.