### PR TITLE
Add patch utility for plugin builder

### DIFF
--- a/plugin-builder/Dockerfile
+++ b/plugin-builder/Dockerfile
@@ -16,7 +16,7 @@ RUN \
   # Install Python, pip and Python modules required by "plugin-release" script.
   && apk add python3-dev && ln -s /usr/bin/python3 /usr/bin/python \
   && apk add py3-pip \
-  && apk add libxml2-dev libxslt-dev && pip install lxml \
+  && apk add libffi-dev libxml2-dev libxslt-dev && pip install lxml \
   && apk add git && pip install gitpython \
   && pip install PyGithub \
   && pip install termcolor \

--- a/plugin-builder/Dockerfile
+++ b/plugin-builder/Dockerfile
@@ -24,6 +24,9 @@ RUN \
   # Install gettext required to build locale files.
   && apk add gettext \
   \
+  # Install patch utility that may be usefull to patch dependencies.
+  && apk add patch \
+  \
   # Remove build dependencies.
   && apk del -f .build-deps \
   \


### PR DESCRIPTION
Some plugins, like barcode, may requires the patch utility to be correctly built.

See https://github.com/pluginsGLPI/barcode/runs/2902184681?check_suite_focus=true#step:5:90