### PR TITLE
Do not build anymore unmaintained DB images

### DIFF
--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -23,16 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {image: "mariadb", version: "10.1", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.2", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.3", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.4", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.5", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.6", config-dir: "/etc/mysql/conf.d"}
-          - {image: "mysql", version: "5.6", config-dir: "/etc/mysql/conf.d"}
           - {image: "mysql", version: "5.7", config-dir: "/etc/mysql/conf.d"}
           - {image: "mysql", version: "8.0", config-dir: "/etc/mysql/conf.d"}
-          - {image: "percona", version: "5.6", config-dir: "/etc/my.cnf.d"}
           - {image: "percona", version: "5.7", config-dir: "/etc/my.cnf.d"}
           - {image: "percona", version: "8.0", config-dir: "/etc/my.cnf.d"}
     env:

--- a/githubactions-db/files/etc/mysql/conf.d/custom.cnf
+++ b/githubactions-db/files/etc/mysql/conf.d/custom.cnf
@@ -8,22 +8,11 @@ optimizer_switch='mrr_cost_based=off'
 datadir=/dev/shm/mysql
 
 
-[mysqld-5.6]
-# Fix support of large prefix in InnoDB indexes
-innodb_file_format=Barracuda
-innodb_large_prefix=ON
-
-
 [mariadb]
 # Tweak cache/buffers
 join_cache_level=8
 join_buffer_size=8M
 mrr_buffer_size=8M
-
-
-[mariadb-10.1]
-# Fix support of large prefix in InnoDB indexes
-innodb_large_prefix=ON
 
 
 [mysqld-8.0]


### PR DESCRIPTION
These DB versions are unmaintained, so it is not necessary to build them each week, as already built images will always be up to date.