### PR TITLE
Add MariaDB 10.9 image; remove MariaDB 10.2 image build

### DIFF
--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {image: "mariadb", version: "10.2", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.3", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.4", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.5", config-dir: "/etc/mysql/conf.d"}

--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -30,6 +30,7 @@ jobs:
           - {image: "mariadb", version: "10.6", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.7", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.8", config-dir: "/etc/mysql/conf.d"}
+          - {image: "mariadb", version: "10.9", config-dir: "/etc/mysql/conf.d"}
           - {image: "mysql", version: "5.7", config-dir: "/etc/mysql/conf.d"}
           - {image: "mysql", version: "8.0", config-dir: "/etc/mysql/conf.d"}
           - {image: "percona", version: "5.7", config-dir: "/etc/my.cnf.d"}


### PR DESCRIPTION
1. MariaDB 10.9 is now released in stable version.
2. MariaDB 10.2 support ended 3 months ago, so already built images will never have to be updated.