### PR TITLE
Do not build PHP 7.4 images anymore

### DIFF
--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {base-image: "php:7.4-fpm-alpine3.15", php-version: "7.4"}
           - {base-image: "php:8.0-fpm-alpine3.15", php-version: "8.0"}
           - {base-image: "php:8.1-fpm-alpine3.15", php-version: "8.1"}
           - {base-image: "php:8.2-rc-fpm-alpine3.15", php-version: "8.2-rc"}


### PR DESCRIPTION
PHP 7.4 will not receive updates anymore, so their is no need to update our PHP 7.4 image every week anymore.