### PR TITLE
Switch to PHP 8.2 stable and use alpine 3.16

### DIFF
--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {base-image: "php:8.0-fpm-alpine3.15", php-version: "8.0"}
-          - {base-image: "php:8.1-fpm-alpine3.15", php-version: "8.1"}
-          - {base-image: "php:8.2-rc-fpm-alpine3.15", php-version: "8.2-rc"}
+          - {base-image: "php:8.0-fpm-alpine3.16", php-version: "8.0"}
+          - {base-image: "php:8.1-fpm-alpine3.16", php-version: "8.1"}
+          - {base-image: "php:8.2-fpm-alpine3.16", php-version: "8.2"}
     steps:
       - name: "Set variables"
         run: |


### PR DESCRIPTION
1. PHP 8.2 stable image is now available.
2. `alpine:3.15` variants are no longer maintained, we have to use `alpine:3.16` now (see https://github.com/docker-library/php/pull/1348).