### PR TITLE
Fixes for alpine 3.16

### DIFF
--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -28,8 +28,6 @@ RUN \
   && docker-php-ext-install exif \
   \
   # Install GD PHP extension.
-  # GD extension configuration parameters changed on PHP 7.4
-  # see https://www.php.net/manual/en/image.installation.php#image.installation
   && apk add freetype-dev libjpeg-turbo-dev libpng-dev \
   && docker-php-ext-configure gd --with-freetype --with-jpeg \
   && docker-php-ext-install gd \
@@ -66,18 +64,13 @@ RUN \
   && docker-php-ext-install zip \
   \
   # Install XMLRPC PHP extension.
+  # Install from Github (extension should be available on PECL but is not)
   && apk add libxml2-dev \
-  && if [[ "$PHP_VERSION" =~ "^7\." ]]; then \
-    # For PHP < 7.x, install bundled extension
-    docker-php-ext-install xmlrpc \
-  ; else \
-    # For PHP 8+, install from Github (extension should be available on PECL but is not)
-    mkdir -p /tmp/xmlrpc \
-    && curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1 \
-    && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
-    && docker-php-ext-install /tmp/xmlrpc \
-    && rm -rf /tmp/xmlrpc \
-  ; fi \
+  && mkdir -p /tmp/xmlrpc \
+  && (curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1) \
+  && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
+  && docker-php-ext-install /tmp/xmlrpc \
+  && rm -rf /tmp/xmlrpc \
   \
   # Install APCU PHP extension.
   && pecl install apcu \

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -91,8 +91,7 @@ RUN \
   && apk add git unzip \
   \
   # Install gettext and perl used to validate locales extraction.
-  # Use edge repository as gettext-0.21 is not available on alpine v3.13 or lower version.
-  && apk add gettext --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ \
+  && apk add gettext \
   && apk add perl \
   \
   # Install sudo that may be usefull to temporarly install upcoming required system components.

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   && docker-php-ext-install gd \
   \
   # Install intl PHP extension.
-  && apk add icu-dev \
+  && apk add icu-dev icu-data-full \
   && docker-php-ext-install intl \
   \
   # Install ldap PHP extension.

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -7,14 +7,6 @@ ARG BASE_IMAGE=php:fpm-alpine
 FROM composer:latest AS composer
 
 #####
-# Fetch composer latest build
-#####
-FROM alpine:3.13 AS iconv_1_15
-
-# Use 'gnu-libiconv' to fix "iconv(): Wrong charset, conversion from `us-ascii' to `UTF-8//TRANSLIT' is not allowed".
-RUN apk add gnu-libiconv
-
-#####
 # Build main image
 #####
 FROM $BASE_IMAGE
@@ -129,9 +121,6 @@ RUN \
 # Copy composer binary
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-#Fix "iconv(): Wrong charset, conversion from `us-ascii' to `UTF-8//TRANSLIT' is not allowed".
-COPY --from=iconv_1_15 /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
-
 # Create application volume (used to share data across jobs),
 # give its ownage to glpi user (1000:1000) and define it as base working dir
 RUN addgroup -g 1000 glpi \
@@ -142,7 +131,3 @@ USER glpi
 VOLUME /home/glpi
 VOLUME /var/glpi
 WORKDIR /var/glpi
-
-ENV \
-  # #Fix "iconv(): Wrong charset, conversion from `us-ascii' to `UTF-8//TRANSLIT' is not allowed".
-  LD_PRELOAD="/usr/lib/preloadable_libiconv.so php-fpm7 php"


### PR DESCRIPTION
1. `gnu-libiconv` is now installed on base image, no need to install it manually (see https://github.com/docker-library/php/pull/1264).

2. ICU data has been splitted in alpine 3.16 and `icu-data-full` has to be installed to have a support of many charsets (see https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split). Without this, our test suite fails:
```
=> tests\units\Toolbox::testFilename():
In file /var/glpi/tests/functionnal/Toolbox.php on line 139, string() failed for data set [7] of data provider filenameProvider: string(8) '24.1.txt' is not identical to string(90) '24.1-zhang-wen-jian-ming-jiang-dao-zhi-nei-rong-chu-zhi-biao-tou-zhong-de-lian-xu-xing.txt'
-Expected
+Actual
@@ -1 +1 @@
-string(90) "24.1-zhang-wen-jian-ming-jiang-dao-zhi-nei-rong-chu-zhi-biao-tou-zhong-de-lian-xu-xing.txt"
+string(8) "24.1.txt"
```

3. Some instructions related to PHP 7.4 were still present.

4. `gettext` package is up-to-date in alpine 3.16, no need to fetch it from an alternative repository.