### PR TITLE
Build MariaDB 11.0 image and remove unmaintained versions

### DIFF
--- a/.github/workflows/githubactions-db.yml
+++ b/.github/workflows/githubactions-db.yml
@@ -23,15 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {image: "mariadb", version: "10.3", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.4", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.5", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.6", config-dir: "/etc/mysql/conf.d"}
-          - {image: "mariadb", version: "10.7", config-dir: "/etc/mysql/conf.d"}
-          - {image: "mariadb", version: "10.8", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.9", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.10", config-dir: "/etc/mysql/conf.d"}
           - {image: "mariadb", version: "10.11", config-dir: "/etc/mysql/conf.d"}
+          - {image: "mariadb", version: "11.0", config-dir: "/etc/mysql/conf.d"}
           - {image: "mysql", version: "5.7", config-dir: "/etc/mysql/conf.d"}
           - {image: "mysql", version: "8.0", config-dir: "/etc/mysql/conf.d"}
           - {image: "percona", version: "5.7", config-dir: "/etc/my.cnf.d"}

--- a/githubactions-db/Dockerfile
+++ b/githubactions-db/Dockerfile
@@ -11,5 +11,9 @@ LABEL \
 ARG CONFIG_DIR=/etc/mysql/conf.d
 COPY ./files/etc/mysql/conf.d/custom.cnf $CONFIG_DIR/custom.cnf
 
+RUN \
+  (test -f /usr/bin/mysql || (test -f /usr/bin/mariadb && ln -s /usr/bin/mariadb /usr/bin/mysql)) \
+  && (test -f /usr/bin/mysqladmin || (test -f /usr/bin/mariadb-admin && ln -s /usr/bin/mariadb-admin /usr/bin/mysqladmin))
+
 HEALTHCHECK --interval=10s --retries=5 --timeout=5s \
   CMD mysqladmin ping


### PR DESCRIPTION
MariaDB 11.0 is now stable.

MariaDB 10.3, 10.7 and 10.8 are no longer maintained. Already build images will still be present in repository and rebuild them is no longer necessary.