### PR TITLE
Build PHP 8.3 pre-release image

### DIFF
--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -26,6 +26,7 @@ jobs:
           - {base-image: "php:8.0-fpm-alpine3.16", php-version: "8.0"}
           - {base-image: "php:8.1-fpm-alpine3.16", php-version: "8.1"}
           - {base-image: "php:8.2-fpm-alpine3.16", php-version: "8.2"}
+          - {base-image: "php:8.3-rc-fpm-alpine3.18", php-version: "8.3-rc"}
     steps:
       - name: "Set variables"
         run: |


### PR DESCRIPTION
`8.3-rc` official docker image is actually an image of PHP 8.3 alpha 1.