### PR TITLE
Fix `netcat` installation on `memcached` image

### DIFF
--- a/githubactions-memcached/Dockerfile
+++ b/githubactions-memcached/Dockerfile
@@ -11,7 +11,7 @@ LABEL \
 # Install netcat for healthcheck
 USER root
 RUN apt-get update \
-  && apt-get install --assume-yes --no-install-recommends --quiet netcat \
+  && apt-get install --assume-yes --no-install-recommends --quiet netcat-traditional \
   && rm -rf /var/lib/apt/lists/*
 
 # Switch back to memcache user


### PR DESCRIPTION
`memcached` base image is now based on Debian Bookworm that has now multiple candidates for the `netcat` virtual package installation.

```
Package netcat is a virtual package provided by:
  netcat-openbsd 1.219-1
  netcat-traditional 1.10-47

E: Package 'netcat' has no installation candidate
```