### PR TITLE
Fix GLPI nightly image Apache configuration

### DIFF
--- a/glpi-nightly/Dockerfile
+++ b/glpi-nightly/Dockerfile
@@ -99,6 +99,9 @@ RUN apt-get update \
   && docker-php-ext-configure zip \
   && docker-php-ext-install zip \
   \
+  # Enable apache mods.
+  && a2enmod rewrite \
+  \
   # Install cron service.
   && apt-get install --assume-yes --no-install-recommends --quiet cron \
   \

--- a/glpi-nightly/files/etc/apache2/sites-available/000-default.conf
+++ b/glpi-nightly/files/etc/apache2/sites-available/000-default.conf
@@ -1,13 +1,19 @@
 <VirtualHost *:80>
-    DocumentRoot /var/www/glpi
+    DocumentRoot /var/www/glpi/public
 
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
 
-    <Directory /var/www/glpi>
-        DirectoryIndex index.php
-        Options FollowSymLinks
+    <Directory /var/www/glpi/public>
         Require all granted
+
+        RewriteEngine On
+
+        # Prevent bearer authorization token filtering
+        RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+        # Redirect all requests to GLPI router, unless file exists.
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^(.*)$ index.php [QSA,L]
     </Directory>
 </VirtualHost>
-


### PR DESCRIPTION
GLPI nightly build of `main` branch is not working anymore as the Apache configuration was not updated according to https://github.com/glpi-project/glpi/pull/14300.

fixes #97 