### PR TITLE
Nightly GLPI images for plugin CI

### DIFF
--- a/.github/workflows/githubactions-glpi.yml
+++ b/.github/workflows/githubactions-glpi.yml
@@ -1,0 +1,66 @@
+name: "GLPI Github Actions GLPI images"
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/githubactions-glpi.yml"
+      - "githubactions-glpi/**"
+  pull_request:
+    paths:
+      - ".github/workflows/githubactions-glpi.yml"
+      - "githubactions-glpi/**"
+  schedule:
+    - cron: '0 0 * * *'
+  # Enable manual run
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "7.4"}
+          - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.0"}
+          - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.1"}
+          - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.2"}
+          - {glpi-branch: "main", glpi-version: "10.1.x", php-version: "8.1"}
+          - {glpi-branch: "main", glpi-version: "10.1.x", php-version: "8.2"}
+    steps:
+      - name: "Set variables"
+        run: |
+          OUTPUTS="type=image"
+          if [[ "${{ github.ref }}" = 'refs/heads/main' && "${{ github.repository }}" = 'glpi-project/docker-images' ]]; then
+              OUTPUTS="$OUTPUTS,push=true"
+          fi
+          echo "OUTPUTS=$OUTPUTS" >> $GITHUB_ENV
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@v3"
+      - name: "Login to DockerHub"
+        uses: "docker/login-action@v3"
+        with:
+          username: "${{ secrets.DOCKER_HUB_USERNAME }}"
+          password: "${{ secrets.DOCKER_HUB_TOKEN }}"
+      - name: "Login to Github container registry"
+        uses: "docker/login-action@v3"
+        with:
+          registry: "ghcr.io"
+          username: "${{ secrets.GHCR_USERNAME }}"
+          password: "${{ secrets.GHCR_ACCESS_TOKEN }}"
+      - name: "Build and push"
+        uses: "docker/build-push-action@v5"
+        with:
+          build-args: |
+            BASE_IMAGE=ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}
+            GLPI_BRANCH=${{ matrix.glpi-branch }}
+          cache-from: "type=gha"
+          cache-to: "type=gha,mode=max"
+          context: "githubactions-glpi"
+          outputs: "${{ env.OUTPUTS }}"
+          pull: true
+          tags: "ghcr.io/glpi-project/githubactions-glpi:php-${{ matrix.php-version }}-glpi-${{ matrix.glpi-version }}"

--- a/githubactions-glpi/Dockerfile
+++ b/githubactions-glpi/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE
+
+FROM $BASE_IMAGE
+
+LABEL \
+  org.opencontainers.image.title="GLPI Github Actions PHP container for GLPI plugins" \
+  org.opencontainers.image.description="This container is used to run GLPI plugins test suites on Github Actions." \
+  org.opencontainers.image.url="https://github.com/glpi-project/docker-images" \
+  org.opencontainers.image.source="git@github.com:glpi-project/docker-images"
+
+ARG GLPI_BRANCH
+
+USER root
+
+# Create a user with UID=1001 (the UID used by Github Actions runner) and give it ownership of the `/var/glpi` directory,
+# so it can checkout the plugin and create config/user files without ACL issues.
+RUN adduser -D -h /home/github-actions-runner -G glpi -u 1001 github-actions-runner \
+  && chown -R github-actions-runner:glpi /var/glpi
+
+USER github-actions-runner
+
+RUN \
+  # Get target GLPI branch source code.
+  git clone --depth=1 --branch=$GLPI_BRANCH https://github.com/glpi-project/glpi /tmp/glpi \
+  && git --git-dir="/tmp/glpi/.git" checkout-index --all --force --prefix="/var/glpi/" \
+  \
+  # Build GLPI.
+  && composer --working-dir=/var/glpi build \
+  \
+  # Clean useless files
+  && rm -rf /tmp/glpi \
+  && rm -rf /var/glpi/node_modules


### PR DESCRIPTION
Provides a nightly GLPI image that can be used in Github Actions by plugins. This image will contains GLPI source (including dev files and dependencies).

This should permit to speed-up plugins CI jobs and to simplify their configuration (see https://github.com/pluginsGLPI/oauthimap/pull/38).