### PR TITLE
Change `ghcr.io/glpi-project/githubactions-glpi` images build schedule

### DIFF
--- a/.github/workflows/githubactions-glpi.yml
+++ b/.github/workflows/githubactions-glpi.yml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/githubactions-glpi.yml"
       - "githubactions-glpi/**"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 22 * * *'
   # Enable manual run
   workflow_dispatch:
 


### PR DESCRIPTION
To ensure that jobs executed on plugins with a `cron: "0 0 * * *"` configuration will use an image that contains most recent commits.