### PR TITLE
PHP 8.0 images will not be updated anymore

### DIFF
--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {base-image: "php:8.0-fpm-alpine3.16", php-version: "8.0"}
           - {base-image: "php:8.1-fpm-alpine3.16", php-version: "8.1"}
           - {base-image: "php:8.2-fpm-alpine3.16", php-version: "8.2"}
           - {base-image: "php:8.3-fpm-alpine3.18", php-version: "8.3"}


### PR DESCRIPTION
As there will be no more update of base PHP 8.0 images, we can remove scheduled rebuild of them. Already built image will still be available.