### PR TITLE
Replace `alpine` by `debian` for GLPI CI images

### DIFF
--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {base-image: "php:8.1-fpm-alpine3.19", php-version: "8.1"}
-          - {base-image: "php:8.2-fpm-alpine3.19", php-version: "8.2"}
-          - {base-image: "php:8.3-fpm-alpine3.19", php-version: "8.3"}
+          - {base-image: "php:8.1-fpm-bullseye", php-version: "8.1"}
+          - {base-image: "php:8.2-fpm-bullseye", php-version: "8.2"}
+          - {base-image: "php:8.3-fpm-bullseye", php-version: "8.3"}
     steps:
       - name: "Set variables"
         run: |

--- a/githubactions-glpi/Dockerfile
+++ b/githubactions-glpi/Dockerfile
@@ -14,7 +14,7 @@ USER root
 
 # Create a user with UID=1001 (the UID used by Github Actions runner) and give it ownership of the `/var/glpi` directory,
 # so it can checkout the plugin and create config/user files without ACL issues.
-RUN adduser -D -h /home/github-actions-runner -G glpi -u 1001 github-actions-runner \
+RUN useradd -m -d /home/github-actions-runner -g glpi -u 1001 github-actions-runner \
   && chown -R github-actions-runner:glpi /var/glpi
 
 USER github-actions-runner

--- a/githubactions-php-coverage/Dockerfile
+++ b/githubactions-php-coverage/Dockerfile
@@ -11,21 +11,9 @@ LABEL \
 USER root
 
 RUN \
-  # Update APK package list.
-  apk update \
-  \
-  # Install PHP build dependencies.
-  && apk add --virtual .build-deps $PHPIZE_DEPS linux-headers \
-  \
   # Install xdebug extension.
-  && pecl install xdebug \
+  pecl install xdebug \
   && docker-php-ext-enable xdebug \
-  && echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-  \
-  # Remove PHP build dependencies.
-  && apk del -f .build-deps \
-  \
-  # Clean sources list.
-  && rm -rf /var/cache/apk/*
+  && echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 USER glpi

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=php:fpm-alpine
+ARG BASE_IMAGE=php:fpm-bullseye
 
 
 #####
@@ -18,32 +18,28 @@ LABEL \
   org.opencontainers.image.source="git@github.com:glpi-project/docker-images"
 
 RUN \
-  # Update APK package list.
-  apk update \
-  \
-  # Install PHP build dependencies.
-  && apk add --virtual .build-deps $PHPIZE_DEPS \
+  # Update package list.
+  apt update \
   \
   # Install exif extension.
   && docker-php-ext-install exif \
   \
   # Install GD PHP extension.
-  && apk add freetype-dev libjpeg-turbo-dev libpng-dev libwebp-dev \
+  && apt install --assume-yes --no-install-recommends --quiet libfreetype6-dev libjpeg-dev libpng-dev libwebp-dev \
   && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
   && docker-php-ext-install gd \
   \
   # Install intl PHP extension.
-  && apk add icu-dev icu-data-full \
+  && apt install --assume-yes --no-install-recommends --quiet libicu-dev \
   && docker-php-ext-install intl \
   \
   # Install ldap PHP extension.
-  && apk add --virtual .ldap-build-deps openldap-dev \
-  && apk add libldap \
+  && apt install --assume-yes --no-install-recommends --quiet libldap2-dev \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
   && docker-php-ext-install ldap \
-  && apk del -f .ldap-build-deps \
   \
   # Install memcached PHP extension.
-  && apk add libmemcached-dev \
+  && apt install --assume-yes --no-install-recommends --quiet libmemcached-dev \
   && pecl install memcached \
   && docker-php-ext-enable memcached \
   \
@@ -58,14 +54,12 @@ RUN \
   && docker-php-ext-enable redis \
   \
   # Install Zip PHP extension.
-  # Zip extension configuration changed on PHP 7.4
-  # see https://www.php.net/manual/en/zip.installation.php
-  && apk add libzip-dev \
+  && apt install --assume-yes --no-install-recommends --quiet libzip-dev \
   && docker-php-ext-install zip \
   \
   # Install XMLRPC PHP extension.
   # Install from Github (extension should be available on PECL but is not)
-  && apk add libxml2-dev \
+  && apt install --assume-yes --no-install-recommends --quiet libxml2-dev \
   && mkdir -p /tmp/xmlrpc \
   && (curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1) \
   && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
@@ -85,41 +79,32 @@ RUN \
   && rm /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini \
   \
   # Install nodejs and npm.
-  && apk add nodejs npm \
+  && apt install --assume-yes --no-install-recommends --quiet gnupg \
+  && mkdir -p /etc/apt/keyrings \
+  && curl --fail --silent --show-error --location https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor --output /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && apt update \
+  && apt install --assume-yes --no-install-recommends --quiet nodejs \
   \
   # Install git and zip used by composer when fetching dependencies.
-  && apk add git unzip \
+  && apt install --assume-yes --no-install-recommends --quiet git unzip \
   \
-  # Install gettext and perl used to validate locales extraction.
-  && apk add gettext \
-  && apk add perl \
+  # Install gettext used for translation files.
+  && apt install --assume-yes --no-install-recommends --quiet gettext \
   \
-  # Install chromium-chromedriver used for front-end tests.
-  && apk add chromium-chromedriver \
+  # Install Cypress dependencies
+  && apt install --assume-yes --no-install-recommends --quiet libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
   \
-  # Install sudo that may be usefull to temporarly install upcoming required system components.
-  && apk add sudo \
-  && (echo "glpi  ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/glpi) \
-  \
-  # Install bash that is used in some GLPI scripts.
-  && apk add bash \
-  \
-  # Install patch utility that may be usefull to patch dependencies.
-  && apk add patch \
-  \
-  # Remove PHP build dependencies.
-  && apk del -f .build-deps \
-  \
-  # Clean sources list.
-  && rm -rf /var/cache/apk/*
+  # Clean sources list
+  && rm -rf /var/lib/apt/lists/*
 
 # Copy composer binary
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Create application volume (used to share data across jobs),
 # give its ownage to glpi user (1000:1000) and define it as base working dir
-RUN addgroup -g 1000 glpi \
-  && adduser -D -h /home/glpi -G glpi -u 1000 glpi \
+RUN addgroup -gid 1000 glpi \
+  && useradd -m -d /home/glpi -g glpi -u 1000 glpi \
   && mkdir -p /var/glpi \
   && chown glpi:glpi /var/glpi
 USER glpi


### PR DESCRIPTION
Replaces #116.

`cypress` cannot be executed on `alpine` images, as some required system packages are not available on `alpine`. See https://github.com/cypress-io/cypress/issues/419.

Executing the existing tests on an `alpine` based image and the new `cypress` tests on a `debian` based image, as proposed in #116 and https://github.com/glpi-project/glpi/pull/16373 will require to fetch both of them in our test suite and will require to maintain both of them. I think it is preferable to switch all of our test suite to a `debian` based image, even if this image will be bigger.

Please note that the CI will fail for the `githubactions-php-coverage` and the `githubactions-glpi` because they will still try to be build using the previous image. This will be fixed once merged.