### PR TITLE
Build PHP 8.4 alpha/beta/rc images

### DIFF
--- a/.github/workflows/githubactions-php-apache.yml
+++ b/.github/workflows/githubactions-php-apache.yml
@@ -26,6 +26,7 @@ jobs:
           - {base-image: "php:8.1-apache-bullseye", php-version: "8.1"}
           - {base-image: "php:8.2-apache-bullseye", php-version: "8.2"}
           - {base-image: "php:8.3-apache-bullseye", php-version: "8.3"}
+          - {base-image: "php:8.4-rc-apache-bullseye", php-version: "8.4-rc"}
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -26,6 +26,7 @@ jobs:
           - {base-image: "php:8.1-fpm-bullseye", php-version: "8.1"}
           - {base-image: "php:8.2-fpm-bullseye", php-version: "8.2"}
           - {base-image: "php:8.3-fpm-bullseye", php-version: "8.3"}
+          - {base-image: "php:8.4-rc-fpm-bullseye", php-version: "8.4-rc"}
     steps:
       - name: "Set variables"
         run: |

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -50,8 +50,17 @@ RUN \
   && docker-php-ext-install pcntl \
   \
   # Install redis PHP extension.
-  && pecl install redis \
-  && docker-php-ext-enable redis \
+  && if [ "$(echo $PHP_VERSION | cut -d '.' -f 1,2)" = "8.4" ]; then \
+    # For PHP 8.4, install from Github (the latest release is not yet compatible)
+    mkdir -p /tmp/redis \
+    && (curl -LsfS https://github.com/phpredis/phpredis/archive/6ea5b3e08bdbf8cbe93e0dc56b18e8316d65097c/phpredis-6ea5b3e.tar.gz | tar xvz -C "/tmp/redis" --strip 1) \
+    && docker-php-ext-configure /tmp/redis \
+    && docker-php-ext-install /tmp/redis \
+    && rm -rf /tmp/redis \
+  ; else \
+    pecl install redis \
+    && docker-php-ext-enable redis \
+  ; fi \
   \
   # Install Zip PHP extension.
   && apt install --assume-yes --no-install-recommends --quiet libzip-dev \


### PR DESCRIPTION
`-rc` actually corresponds to the `alpha1` version, and will then automatically switch to the `beta` and `rc` versions.