### PR TITLE
Build PHP 8.4 images

### DIFF
--- a/.github/workflows/githubactions-glpi-apache.yml
+++ b/.github/workflows/githubactions-glpi-apache.yml
@@ -30,6 +30,7 @@ jobs:
           - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.3"}
           - {glpi-branch: "main", glpi-version: "11.0.x", php-version: "8.2"}
           - {glpi-branch: "main", glpi-version: "11.0.x", php-version: "8.3"}
+          - {glpi-branch: "main", glpi-version: "11.0.x", php-version: "8.4"}
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php-apache.yml
+++ b/.github/workflows/githubactions-php-apache.yml
@@ -26,6 +26,7 @@ jobs:
           - {base-image: "php:8.1-apache-bullseye", php-version: "8.1"}
           - {base-image: "php:8.2-apache-bullseye", php-version: "8.2"}
           - {base-image: "php:8.3-apache-bullseye", php-version: "8.3"}
+          - {base-image: "php:8.4-apache-bullseye", php-version: "8.4"}
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php-coverage.yml
+++ b/.github/workflows/githubactions-php-coverage.yml
@@ -26,6 +26,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -26,6 +26,7 @@ jobs:
           - {base-image: "php:8.1-fpm-bullseye", php-version: "8.1"}
           - {base-image: "php:8.2-fpm-bullseye", php-version: "8.2"}
           - {base-image: "php:8.3-fpm-bullseye", php-version: "8.3"}
+          - {base-image: "php:8.4-fpm-bullseye", php-version: "8.4"}
     steps:
       - name: "Set variables"
         run: |


### PR DESCRIPTION
The build of the PHP image with xdebug will not be possible since xdebug is not yet compatible with this PHP version, see https://xdebug.org/docs/compat.