### PR TITLE
Use PHP 8.3 on GLPI dev image

### DIFF
--- a/.github/workflows/glpi-development-env.yml
+++ b/.github/workflows/glpi-development-env.yml
@@ -46,7 +46,7 @@ jobs:
         uses: "docker/build-push-action@v6"
         with:
           build-args: |
-            BASE_IMAGE=php:apache-bullseye
+            BASE_IMAGE=php:8.3-apache-bullseye
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
           context: "glpi-development-env"


### PR DESCRIPTION
The latest PHP image is now the PHP 8.4 image, but GLPI 10.0 dependencies have many unfixed deprecations that would pollute the logs. Using PHP 8.3 is preferable for now.
Also, since xdebug is not yet available for PHP 8.4, the build is broken, see https://github.com/glpi-project/docker-images/actions/runs/12001165435/job/33451291729.