### PR TITLE
Enable the xdebug debug mode by default on dev image

### DIFF
--- a/glpi-development-env/files/etc/php/conf.d/glpi.ini
+++ b/glpi-development-env/files/etc/php/conf.d/glpi.ini
@@ -3,5 +3,6 @@
 session.cookie_httponly = on
 
 [xdebug]
-xdebug.mode=develop
+xdebug.mode=develop,debug
 xdebug.start_with_request=trigger
+xdebug.client_host=host.docker.internal


### PR DESCRIPTION
The debug mode has no noticeable impact on performances. Enabling it by default permit to have an out of the box default configuration for step-by-step debugging.