### PR TITLE
fix openldap CMD crash (ulimit)

### DIFF
--- a/githubactions-openldap/Dockerfile
+++ b/githubactions-openldap/Dockerfile
@@ -23,5 +23,5 @@ COPY ./files/etc/openldap/slapd.conf /etc/openldap/slapd.conf
 HEALTHCHECK --interval=10s --retries=5 --timeout=5s \
   CMD ldapwhoami  -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure || exit 1
 
-CMD ["slapd", "-d", "32768", "-h", "ldap://0.0.0.0:3890/"]
+CMD ["/bin/sh", "-c", "ulimit -n 1024 && slapd -d 32768 -h \"ldap://0.0.0.0:3890/\""]
  


### PR DESCRIPTION
On some OS the ldap server fails to start with error.

> 6784d95e.2dd30b8c 0x7fde4bf44b28 ch_calloc of 1 elems of 60129541696 bytes failed Assertion failed: 0 (ch_malloc.c: ch_calloc: 107)

This is related to ulimit too low.
ulimit -n 1024 fix the problem.
