### PR TITLE
Build development env with multiple PHP versions

### DIFF
--- a/.github/workflows/glpi-development-env.yml
+++ b/.github/workflows/glpi-development-env.yml
@@ -19,6 +19,13 @@ on:
 jobs:
   build:
     runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["7.4", "8.0", "8.1", "8.3"]
+        latest: ["false"]
+        include:
+          - {php-version: "8.4", latest: "true"}
     steps:
       - name: "Set variables"
         run: |
@@ -46,10 +53,10 @@ jobs:
         uses: "docker/build-push-action@v6"
         with:
           build-args: |
-            BASE_IMAGE=php:8.3-apache-bullseye
+            BASE_IMAGE=php:${{ matrix.php-version }}-apache-bullseye
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
           context: "glpi-development-env"
           outputs: "${{ env.OUTPUTS }}"
           pull: true
-          tags: "ghcr.io/glpi-project/glpi-development-env:latest"
+          tags: "ghcr.io/glpi-project/glpi-development-env:${{ matrix.php-version }}${{ matrix.latest == 'true' && ',ghcr.io/glpi-project/glpi-development-env:latest' || '' }}"

--- a/glpi-development-env/Dockerfile
+++ b/glpi-development-env/Dockerfile
@@ -18,6 +18,7 @@ LABEL \
   org.opencontainers.image.source="git@github.com:glpi-project/docker-images"
 
 RUN apt update \
+  && PHP_MAJOR_VERSION="$(echo $PHP_VERSION | cut -d '.' -f 1)" \
   \
   # Install bz2 extension (for marketplace).
   && apt install --assume-yes --no-install-recommends --quiet libbz2-dev \
@@ -66,17 +67,26 @@ RUN apt update \
   && docker-php-ext-install zip \
   \
   # Install xdebug PHP extension.
-  && pecl install xdebug \
+  && if [ $PHP_MAJOR_VERSION -lt "8" ]; then \
+    pecl install xdebug-3.1.6 \
+  ; else \
+    pecl install xdebug \
+  ; fi \
   && docker-php-ext-enable xdebug \
   \
   # Install XMLRPC PHP extension.
-  # Install from Github (extension should be available on PECL but is not)
   && apt install --assume-yes --no-install-recommends --quiet libxml2-dev \
-  && mkdir -p /tmp/xmlrpc \
-  && (curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1) \
-  && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
-  && docker-php-ext-install /tmp/xmlrpc \
-  && rm -rf /tmp/xmlrpc \
+  && if [ $PHP_MAJOR_VERSION -lt "8" ]; then \
+    # For PHP < 8.x, install bundled extension
+    docker-php-ext-install xmlrpc \
+  ; else \
+    # For PHP 8+, install from Github (extension should be available on PECL but is not)
+    mkdir -p /tmp/xmlrpc \
+    && curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1 \
+    && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
+    && docker-php-ext-install /tmp/xmlrpc \
+    && rm -rf /tmp/xmlrpc \
+  ; fi \
   \
   # Enable apache mods.
   && a2enmod rewrite \


### PR DESCRIPTION
I recently required a PHP 7.4 env to fix a bug that was present only on PHP 7.4. I had to use a custom docker build because our official developement env was only available with PHP 8.3.

Having official development env for all supported PHP versions would be useful.