### PR TITLE
Install latest gettext version

### DIFF
--- a/githubactions-php-apache/Dockerfile
+++ b/githubactions-php-apache/Dockerfile
@@ -64,7 +64,7 @@ RUN \
   # Install from Github (extension should be available on PECL but is not)
   && apt install --assume-yes --no-install-recommends --quiet libxml2-dev \
   && mkdir -p /tmp/xmlrpc \
-  && (curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1) \
+  && (curl --fail --silent --show-error --location https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/xmlrpc" --strip 1) \
   && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
   && docker-php-ext-install /tmp/xmlrpc \
   && rm -rf /tmp/xmlrpc \
@@ -96,7 +96,10 @@ RUN \
   && apt install --assume-yes --no-install-recommends --quiet git unzip \
   \
   # Install gettext used for translation files.
-  && apt install --assume-yes --no-install-recommends --quiet gettext \
+  && mkdir -p /tmp/gettext \
+  && (curl -LsfS https://ftp.gnu.org/pub/gnu/gettext/gettext-0.25.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/gettext" --strip 1) \
+  && (cd /tmp/gettext && ./configure && make && make install) \
+  && rm -rf /tmp/gettext \
   \
   # Install Cypress dependencies
   && apt install --assume-yes --no-install-recommends --quiet libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb \

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -64,7 +64,7 @@ RUN \
   # Install from Github (extension should be available on PECL but is not)
   && apt install --assume-yes --no-install-recommends --quiet libxml2-dev \
   && mkdir -p /tmp/xmlrpc \
-  && (curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1) \
+  && (curl --fail --silent --show-error --location https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/xmlrpc" --strip 1) \
   && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
   && docker-php-ext-install /tmp/xmlrpc \
   && rm -rf /tmp/xmlrpc \
@@ -93,7 +93,10 @@ RUN \
   && apt install --assume-yes --no-install-recommends --quiet git unzip \
   \
   # Install gettext used for translation files.
-  && apt install --assume-yes --no-install-recommends --quiet gettext \
+  && mkdir -p /tmp/gettext \
+  && (curl -LsfS https://ftp.gnu.org/pub/gnu/gettext/gettext-0.25.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/gettext" --strip 1) \
+  && (cd /tmp/gettext && ./configure && make && make install) \
+  && rm -rf /tmp/gettext \
   \
   # Install Cypress dependencies
   && apt install --assume-yes --no-install-recommends --quiet libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
@@ -114,6 +117,10 @@ USER glpi
 VOLUME /home/glpi
 VOLUME /var/www/glpi
 WORKDIR /var/www/glpi
+
+# Define the library path where built gettext shared libraries are located
+ENV \
+  LD_LIBRARY_PATH="/usr/local/lib"
 
 # Define GLPI environment variables
 ENV \

--- a/glpi-development-env/Dockerfile
+++ b/glpi-development-env/Dockerfile
@@ -82,7 +82,7 @@ RUN apt update \
   ; else \
     # For PHP 8+, install from Github (extension should be available on PECL but is not)
     mkdir -p /tmp/xmlrpc \
-    && curl -LsfS https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar xvz -C "/tmp/xmlrpc" --strip 1 \
+    && (curl --fail --silent --show-error --location https://github.com/php/pecl-networking-xmlrpc/archive/0f782ffe52cebd0a65356427b7ab72d48b72d20c/xmlrpc-0f782ff.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/xmlrpc" --strip 1) \
     && docker-php-ext-configure /tmp/xmlrpc --with-xmlrpc \
     && docker-php-ext-install /tmp/xmlrpc \
     && rm -rf /tmp/xmlrpc \
@@ -103,7 +103,10 @@ RUN apt update \
   && apt install --assume-yes --no-install-recommends --quiet git unzip \
   \
   # Install gettext used for translation files.
-  && apt install --assume-yes --no-install-recommends --quiet gettext \
+  && mkdir -p /tmp/gettext \
+  && (curl -LsfS https://ftp.gnu.org/pub/gnu/gettext/gettext-0.25.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/gettext" --strip 1) \
+  && (cd /tmp/gettext && ./configure && make && make install) \
+  && rm -rf /tmp/gettext \
   \
   # Install Cypress dependencies
   && apt install --assume-yes --no-install-recommends --quiet libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb \


### PR DESCRIPTION
Our debian based images used on our developement machines and used on th CI have the 0.21 version of `gettext` installed. It prevents to get some warnings related to a mix between singular and pluralized messages (e.g. `__('Comment')` VS `_n('Comment', 'Comments', $count)`.
Also, the issue related to indented HEREDOC/NOWDOC closing marker has been fixed in the 0.23 version.

The only way to get a more recent version, ATM, is to install it from the sources.