### PR TITLE
Expose e2e env under a specific port

### DIFF
--- a/glpi-development-env/Dockerfile
+++ b/glpi-development-env/Dockerfile
@@ -131,6 +131,8 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 # Copy files to container.
+COPY ./files/etc/apache2/ports.conf /etc/apache2/ports.conf
+COPY ./files/etc/apache2/conf-available/glpi-common.conf /etc/apache2/conf-available/glpi-common.conf
 COPY ./files/etc/apache2/sites-available/000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY ./files/etc/php/conf.d/glpi.ini $PHP_INI_DIR/conf.d/glpi.ini
 

--- a/glpi-development-env/files/etc/apache2/conf-available/glpi-common.conf
+++ b/glpi-development-env/files/etc/apache2/conf-available/glpi-common.conf
@@ -1,0 +1,17 @@
+DocumentRoot /var/www/glpi/public
+
+ErrorLog ${APACHE_LOG_DIR}/error.log
+CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+<Directory /var/www/glpi/public>
+    Require all granted
+
+    RewriteEngine On
+
+    # Prevent bearer authorization token filtering
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+    # Redirect all requests to GLPI router, unless file exists.
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^(.*)$ index.php [QSA,L]
+</Directory>

--- a/glpi-development-env/files/etc/apache2/ports.conf
+++ b/glpi-development-env/files/etc/apache2/ports.conf
@@ -1,0 +1,3 @@
+Listen 80
+Listen 8880
+

--- a/glpi-development-env/files/etc/apache2/sites-available/000-default.conf
+++ b/glpi-development-env/files/etc/apache2/sites-available/000-default.conf
@@ -1,19 +1,8 @@
 <VirtualHost *:80>
-    DocumentRoot /var/www/glpi/public
+    Include conf-available/glpi-common.conf
+</VirtualHost>
 
-    ErrorLog ${APACHE_LOG_DIR}/error.log
-    CustomLog ${APACHE_LOG_DIR}/access.log combined
-
-    <Directory /var/www/glpi/public>
-        Require all granted
-
-        RewriteEngine On
-
-        # Prevent bearer authorization token filtering
-        RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-
-        # Redirect all requests to GLPI router, unless file exists.
-        RewriteCond %{REQUEST_FILENAME} !-f
-        RewriteRule ^(.*)$ index.php [QSA,L]
-    </Directory>
+<VirtualHost *:8880>
+    SetEnv GLPI_ENVIRONMENT_TYPE e2e_testing
+    Include conf-available/glpi-common.conf
 </VirtualHost>


### PR DESCRIPTION
As discussed together a while ago @cedric-anne, this will allow devs to run e2e tests in a specific env locally, which is more convenient as it avoid polluting the dev or testing databases.

Implemented as you suggested:
* Apache now listen for both 80 and 8880
* behavior on port 80 is unchanged
* port 8880 set the specific env variable

I still need to do the changes in the playwright PR side, but I supposed it is easier if this is merged first.