### PR TITLE
Explicitely define environments in apache vhosts

### DIFF
--- a/githubactions-php-apache/files/etc/apache2/sites-available/000-default.conf
+++ b/githubactions-php-apache/files/etc/apache2/sites-available/000-default.conf
@@ -1,4 +1,6 @@
 <VirtualHost *:80>
+    SetEnv GLPI_ENVIRONMENT_TYPE testing
+
     DocumentRoot /var/www/glpi/public
     <Directory /var/www/glpi/public>
         Require all granted

--- a/glpi-development-env/files/etc/apache2/sites-available/000-default.conf
+++ b/glpi-development-env/files/etc/apache2/sites-available/000-default.conf
@@ -1,8 +1,11 @@
 <VirtualHost *:80>
+    SetEnv GLPI_ENVIRONMENT_TYPE development
+
     Include vhosts/glpi-common.conf
 </VirtualHost>
 
 <VirtualHost *:8090>
     SetEnv GLPI_ENVIRONMENT_TYPE e2e_testing
+
     Include vhosts/glpi-common.conf
 </VirtualHost>


### PR DESCRIPTION
In the plugins CI workflow, Apache is started manually with a sudo command and it does not seems to use the env variable defined in the `Dockerfile`. Setting it explicitely using the `SetEnv` apache directive should fix this issue.