### PR TITLE
allow selecting php version

### DIFF
--- a/.github/workflows/glpi.yml
+++ b/.github/workflows/glpi.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: ""
+      php-version:
+        type: string
+        required: true
+        default: "8.4"
     secrets:
       DOCKER_HUB_USERNAME:
         required: true
@@ -41,6 +45,11 @@ on:
         required: false
         type: string
         default: ""
+      php-version:
+        description: "PHP version to use for the build"
+        required: true
+        type: string
+        default: "8.4"
 
 jobs:
   build:
@@ -102,8 +111,8 @@ jobs:
         uses: "docker/build-push-action@v6"
         with:
           build-args: |
-            BUILDER_IMAGE=php:8.4-cli-alpine
-            APP_IMAGE=php:8.4-apache
+            BUILDER_IMAGE=php:${{inputs.php-version}}-cli-alpine
+            APP_IMAGE=php:${{inputs.php-version}}-apache
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
           context: "glpi"


### PR DESCRIPTION
Add again PHP-version selection
At least, allow to rebuild manually an image that has been built with a wrong version (recent example 10.0.18 is not compatible with php8.4)

Later, we may extract the value from the main repository composer.json if we change it to something like that, no?

**composer.json**
```
{
   ...
    "require": {
      "php": ">=7.4 <8.4",
    }
}
