### PR TITLE
forward logs to stdout/stderr of container

### DIFF
--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -137,6 +137,15 @@ ENV \
   GLPI_CONFIG_DIR=/var/glpi/config \
   GLPI_VAR_DIR=/var/glpi/files
 
+# Forward GLPI logs to stdout/stderr.
+RUN ln -sf /dev/stdout /var/glpi/files/_log/event.log \
+  && ln -sf /dev/stdout /var/glpi/files/_log/cron.log \
+  && ln -sf /dev/stdout /var/glpi/files/_log/mail.log \
+  && ln -sf /dev/stderr /var/glpi/files/_log/php_errors.log \
+  && ln -sf /dev/stderr /var/glpi/files/_log/sql-errors.log \
+  && ln -sf /dev/stderr /var/glpi/files/_log/mail-errors.log \
+  && ln -sf /dev/stderr /var/glpi/files/_log/access-errors.log
+
 # Make startup script executable and executes it as default command.
 RUN chmod u+x /opt/startup.sh
 CMD /opt/startup.sh


### PR DESCRIPTION
Inspired by [nginx Dockerfile](https://github.com/nginx/docker-nginx/blob/8921999083def7ba43a06fabd5f80e4406651353/mainline/jessie/Dockerfile#L21-L23)

I'm not sure the trick works if GLPI checks somewhere for the existence of the log files.
Also, do we need to set some acl on these symlinks ?