### PR TITLE
Fix `glpi/glpi` files volume init/ACLs handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ services:
     image: "glpi/glpi:latest"
     restart: "unless-stopped"
     volumes:
-      - "./storage/glpi/config:/var/www/glpi/config:rw"
-      - "./storage/glpi/files:/var/www/glpi/files:rw"
-      - "./storage/glpi/plugins:/var/www/glpi/marketplace:rw"
+      - "./storage/glpi:/var/glpi:rw"
     depends_on:
       - "db"
     ports:
@@ -60,9 +58,4 @@ At the time of database creation, you can use the following credentials:
 
 ### Volumes
 
-By default `glpi/glpi` images doesn't include any volumes.
-There is a consensus to declare these:
-
-- `/var/www/glpi/config` where database config and cryptography files are stored
-- `/var/www/glpi/files` where GLPI stores its files, such as uploaded documents, images, etc.
-- `/var/www/glpi/marketplace` where GLPI stores its plugins
+By default, the `glpi/glpi` image provides a volume containing its `config`, `marketplace` and `files` directories.

--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -131,14 +131,15 @@ RUN crontab -u www-data /etc/cron.d/glpi
 # Copy GLPI application.
 COPY --from=builder --chown=www-data:www-data /usr/src/glpi /var/www/glpi
 
-# Declare a volume for "config" and "files" directory
+# Declare a volume for "config", "marketplace" and "files" directory
 RUN mkdir /var/glpi && chown www-data:www-data /var/glpi
 VOLUME /var/glpi
 
 # Define GLPI environment variables
 ENV \
   GLPI_INSTALL_MODE=DOCKER \
-  GLPI_CONFIG_DIR=/var/glpi/config \
+  GLPI_CONFIG_DIR=/var/glpi/config  \
+  GLPI_MARKETPLACE_DIR=/var/glpi/marketplace \
   GLPI_VAR_DIR=/var/glpi/files
 
 # Make startup script executable and executes it as default command.

--- a/glpi/files/opt/startup.sh
+++ b/glpi/files/opt/startup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Create config and files volume (sub)directories that are missing
+# Create `config`, `marketplace` and `files` volume (sub)directories that are missing
 # and set ACL for www-data user
 dirs=(
     "/var/glpi/config"
@@ -19,22 +19,24 @@ dirs=(
     "/var/glpi/files/_tmp"
     "/var/glpi/files/_uploads"
     "/var/glpi/files/_inventories"
+    "/var/glpi/marketplace"
 )
 for dir in "${dirs[@]}"
 do
     if [ ! -d "$dir" ]
     then
+        echo "Creating $dir..."
         mkdir "$dir"
     fi
-    setfacl -m user:www-data:rwx,group:www-data:rwx "$dir"
+    echo "Setting $dir ACLs..."
+    chown -R www-data:www-data "$dir"
+    chmod u+rwx "$dir"
+    find "$dir" -type d -exec chmod u+rwx {} \;
+    find "$dir" -type f -exec chmod u+rw {} \;
 done
-
-# Set ACL for www-data user on marketplace directory
-setfacl -m user:www-data:rwx,group:www-data:rwx "/var/www/glpi/marketplace"
 
 # Run cron service.
 cron
 
 # Run command previously defined in base php-apache Dockerfile.
 apache2-foreground
-


### PR DESCRIPTION
1. Use `chown`/`chmod` for NFS v4 compatibility.
2. Add missing `GLPI_MARKETPLACE_DIR` override.
3. Fix readme that wrongly indicates that there are no declared volumes (`/var/glpi` is declared as a volume).
4. Use a single volume in the `docker-compose.yaml` file example.

Includes and replace #151.