### PR TITLE
remove required attribute for php-version

### DIFF
--- a/.github/workflows/glpi.yml
+++ b/.github/workflows/glpi.yml
@@ -12,6 +12,7 @@ on:
         type: string
         default: ""
       php-version:
+        required: false
         type: string
         default: "8.4"
     secrets:


### PR DESCRIPTION
Try to fix failing build: https://github.com/glpi-project/glpi/actions/runs/16020079696
Aparently a required attribute with default value is still required to be passed by another workflow.