### PR TITLE
Expose e2e testing as 8090 for githubactions-php-apache

### DIFF
--- a/githubactions-php-apache/Dockerfile
+++ b/githubactions-php-apache/Dockerfile
@@ -118,6 +118,9 @@ RUN \
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Copy files to container
+RUN mkdir /etc/apache2/vhosts
+COPY ./files/etc/apache2/ports.conf /etc/apache2/ports.conf
+COPY ./files/etc/apache2/vhosts/glpi-common.conf /etc/apache2/vhosts/glpi-common.conf
 COPY ./files/etc/apache2/sites-available/000-default.conf /etc/apache2/sites-available/000-default.conf
 
 RUN \

--- a/githubactions-php-apache/files/etc/apache2/ports.conf
+++ b/githubactions-php-apache/files/etc/apache2/ports.conf
@@ -1,0 +1,3 @@
+Listen 80
+Listen 8090
+

--- a/githubactions-php-apache/files/etc/apache2/sites-available/000-default.conf
+++ b/githubactions-php-apache/files/etc/apache2/sites-available/000-default.conf
@@ -1,12 +1,9 @@
 <VirtualHost *:80>
     SetEnv GLPI_ENVIRONMENT_TYPE testing
+    Include vhosts/glpi-common.conf
+</VirtualHost>
 
-    DocumentRoot /var/www/glpi/public
-    <Directory /var/www/glpi/public>
-        Require all granted
-        RewriteEngine On
-        RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-        RewriteCond %{REQUEST_FILENAME} !-f
-        RewriteRule ^(.*)$ index.php [QSA,L]
-    </Directory>
+<VirtualHost *:8090>
+    SetEnv GLPI_ENVIRONMENT_TYPE e2e_testing
+    Include vhosts/glpi-common.conf
 </VirtualHost>

--- a/githubactions-php-apache/files/etc/apache2/vhosts/glpi-common.conf
+++ b/githubactions-php-apache/files/etc/apache2/vhosts/glpi-common.conf
@@ -1,0 +1,9 @@
+DocumentRoot /var/www/glpi/public
+
+<Directory /var/www/glpi/public>
+    Require all granted
+    RewriteEngine On
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^(.*)$ index.php [QSA,L]
+</Directory>


### PR DESCRIPTION
Since https://github.com/glpi-project/docker-images/pull/145 force the `testing` env on the 80 port, there is no way to override GLPI's environment.
This is problematic for e2e testing.

These changes expose the e2e environment through the 8090 port as it was already done for the dev environment.