### PR TITLE
Fix GLPI cron execution

### DIFF
--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -126,7 +126,7 @@ COPY ./files/etc/php/conf.d/glpi.ini $PHP_INI_DIR/conf.d/glpi.ini
 COPY ./files/opt/startup.sh /opt/startup.sh
 
 # Install GLPI crontab.
-RUN crontab -u www-data /etc/cron.d/glpi
+RUN crontab -u root /etc/cron.d/glpi
 
 # Copy GLPI application.
 COPY --from=builder --chown=www-data:www-data /usr/src/glpi /var/www/glpi
@@ -142,6 +142,9 @@ ENV \
   GLPI_MARKETPLACE_DIR=/var/glpi/marketplace \
   GLPI_VAR_DIR=/var/glpi/files \
   GLPI_LOG_DIR=/var/glpi/logs
+
+# Copy the env variables to `/etc/environment`, to make them available for the commands executed by the cron service
+RUN printenv > /etc/environment
 
 # Make startup script executable and executes it as default command.
 RUN chmod u+x /opt/startup.sh

--- a/glpi/files/etc/cron.d/glpi
+++ b/glpi/files/etc/cron.d/glpi
@@ -1,1 +1,1 @@
-* * * * *    /usr/local/bin/php /var/www/glpi/front/cron.php &>/dev/null
+* * * * * su www-data -s /usr/local/bin/php /var/www/glpi/front/cron.php 2>> /var/log/cron-errors.log 1>> /var/log/cron-output.log

--- a/glpi/files/opt/startup.sh
+++ b/glpi/files/opt/startup.sh
@@ -76,6 +76,10 @@ do
 done
 
 # Run cron service.
+touch /var/log/cron-output.log
+touch /var/log/cron-errors.log
+tail -F /var/log/cron-output.log &
+tail -F /var/log/cron-errors.log &
 cron
 
 # Run command previously defined in base php-apache Dockerfile.


### PR DESCRIPTION
- make env variables available in the cron context
- forward cron logs to the docker logs

fixes #166