### PR TITLE
Add `glpi/sources` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+glpi/sources/
 glpi-nightly/sources/


### PR DESCRIPTION
It will prevent to accidentally add this directory in a commit.