### PR TITLE
Add PHP 8.5 images

### DIFF
--- a/.github/workflows/githubactions-glpi-apache.yml
+++ b/.github/workflows/githubactions-glpi-apache.yml
@@ -29,9 +29,11 @@ jobs:
           - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.2"}
           - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.3"}
           - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.4"}
+          - {glpi-branch: "10.0/bugfixes", glpi-version: "10.0.x", php-version: "8.5"}
           - {glpi-branch: "main", glpi-version: "11.0.x", php-version: "8.2"}
           - {glpi-branch: "main", glpi-version: "11.0.x", php-version: "8.3"}
           - {glpi-branch: "main", glpi-version: "11.0.x", php-version: "8.4"}
+          - {glpi-branch: "main", glpi-version: "11.0.x", php-version: "8.5"}
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php-apache.yml
+++ b/.github/workflows/githubactions-php-apache.yml
@@ -27,6 +27,7 @@ jobs:
           - {base-image: "php:8.2-apache-bullseye", php-version: "8.2"}
           - {base-image: "php:8.3-apache-bullseye", php-version: "8.3"}
           - {base-image: "php:8.4-apache-bullseye", php-version: "8.4"}
+          - {base-image: "php:8.5-rc-apache-bullseye", php-version: "8.5"}
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php-coverage.yml
+++ b/.github/workflows/githubactions-php-coverage.yml
@@ -27,6 +27,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -27,6 +27,7 @@ jobs:
           - {base-image: "php:8.2-fpm-bullseye", php-version: "8.2"}
           - {base-image: "php:8.3-fpm-bullseye", php-version: "8.3"}
           - {base-image: "php:8.4-fpm-bullseye", php-version: "8.4"}
+          - {base-image: "php:8.5-rc-fpm-bullseye", php-version: "8.5"}
     steps:
       - name: "Set variables"
         run: |


### PR DESCRIPTION
Builds will fail, for the moment. It should be OK once 8.5.0alpha2 will be released thanks to https://github.com/php/php-src/commit/840dc1981f90edca0bbbdace5e19c3118525e75a.