### PR TITLE
Build `githubactions-dovecot` image from debian `bookworm`

### DIFF
--- a/.github/workflows/githubactions-dovecot.yml
+++ b/.github/workflows/githubactions-dovecot.yml
@@ -45,8 +45,6 @@ jobs:
       - name: "Build and push"
         uses: "docker/build-push-action@v6"
         with:
-          build-args: |
-            BASE_IMAGE=debian:buster-slim
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
           context: "githubactions-dovecot"

--- a/githubactions-dovecot/Dockerfile
+++ b/githubactions-dovecot/Dockerfile
@@ -1,6 +1,4 @@
-ARG BASE_IMAGE=debian:buster-slim
-
-FROM $BASE_IMAGE
+FROM debian:bookworm-slim
 
 LABEL \
   org.opencontainers.image.title="GLPI Github Actions Dovecot container" \
@@ -21,7 +19,7 @@ RUN \
   && apt-get update \
   \
   # Install mail server and getmail utility.
-  && apt-get install --assume-yes --no-install-recommends --quiet dovecot-imapd dovecot-pop3d getmail4 \
+  && apt-get install --assume-yes --no-install-recommends --quiet dovecot-imapd dovecot-pop3d getmail6 \
   && maildirmake.dovecot /home/glpi/Maildir glpi \
   \
   # Clean sources list.


### PR DESCRIPTION
The `debian:buster-slim` image cannot be used anymore as the apt repositories are not accessible anymore.