### PR TITLE
Define ENVs so that existing prods don't crash

### DIFF
--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -150,8 +150,8 @@ ENV \
   GLPI_CONFIG_DIR=/var/glpi/config \
   GLPI_MARKETPLACE_DIR=/var/glpi/marketplace \
   GLPI_VAR_DIR=/var/glpi/files \
-  GLPI_LOG_DIR=/var/glpi/logs
-  GLPI_SKIP_AUTOINSTALL=false
+  GLPI_LOG_DIR=/var/glpi/logs \
+  GLPI_SKIP_AUTOINSTALL=false \
   GLPI_SKIP_AUTOUPDATE=false
 
 # Copy the env variables to `/etc/environment`, to make them available for the commands executed by the cron service

--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -151,6 +151,8 @@ ENV \
   GLPI_MARKETPLACE_DIR=/var/glpi/marketplace \
   GLPI_VAR_DIR=/var/glpi/files \
   GLPI_LOG_DIR=/var/glpi/logs
+  GLPI_SKIP_AUTOINSTALL=false
+  GLPI_SKIP_AUTOUPDATE=false
 
 # Copy the env variables to `/etc/environment`, to make them available for the commands executed by the cron service
 RUN printenv > /etc/environment


### PR DESCRIPTION
This PR adds a default value `false` to `GLPI_SKIP_AUTOINSTALL` and `GLPI_SKIP_AUTOUPDATE`, so that it doesn't break already existing setups.

This closes #175 