### PR TITLE
Set the correct `GLPI_MARKETPLACE_DIR` value at build time

### DIFF
--- a/.github/workflows/glpi.yml
+++ b/.github/workflows/glpi.yml
@@ -60,8 +60,11 @@ jobs:
         id: "variables"
         run: |
           IMAGE_VERSION="$(echo '${{ inputs.glpi-version }}' | sed -E 's|/|-|')"
+          IMAGE_VERSION_MAJOR=$(echo "${{ inputs.glpi-version }}" | cut -d. -f1)
+          IMAGE_VERSION_MINOR=$(echo "${{ inputs.glpi-version }}" | cut -d. -f1-2)
+
           if [[ "${{ inputs.image-suffix }}" != '' ]]; then
-              IMAGE_VERSION="$IMAGE_VERSION-${{ inputs.image-suffix }}"
+            IMAGE_VERSION="$IMAGE_VERSION-${{ inputs.image-suffix }}"
           fi
 
           # prepare the tags to push
@@ -69,22 +72,25 @@ jobs:
 
           PRERELEASE_FLAG="$( echo "${{ inputs.glpi-version }}" | grep -Po '(\-\w+)?$' )"
           if [[ -z "$PRERELEASE_FLAG" ]]; then
-              # populate major version tags, ex 10.0.18 -> 10
-              IMAGE_VERSION_MAJOR=$(echo "${{ inputs.glpi-version }}" | cut -d. -f1)
-              TAGS="$TAGS,glpi/glpi:$IMAGE_VERSION_MAJOR,ghcr.io/glpi-project/glpi:$IMAGE_VERSION_MAJOR"
+            # populate major version tags, ex 10.0.18 -> 10
+            TAGS="$TAGS,glpi/glpi:$IMAGE_VERSION_MAJOR,ghcr.io/glpi-project/glpi:$IMAGE_VERSION_MAJOR"
 
-              # populate minor version tags, ex 10.0.18 -> 10.0
-              IMAGE_VERSION_MINOR=$(echo "${{ inputs.glpi-version }}" | cut -d. -f1-2)
-              TAGS="$TAGS,glpi/glpi:$IMAGE_VERSION_MINOR,ghcr.io/glpi-project/glpi:$IMAGE_VERSION_MINOR"
+            # populate minor version tags, ex 10.0.18 -> 10.0
+            TAGS="$TAGS,glpi/glpi:$IMAGE_VERSION_MINOR,ghcr.io/glpi-project/glpi:$IMAGE_VERSION_MINOR"
 
             # find if the current version is the latest
             if [[ "${{ inputs.glpi-version }}" = "$(curl -s https://api.github.com/repos/glpi-project/glpi/releases/latest | jq -r .tag_name)" ]]; then
-                TAGS="$TAGS,glpi/glpi:latest,ghcr.io/glpi-project/glpi:latest"
+              TAGS="$TAGS,glpi/glpi:latest,ghcr.io/glpi-project/glpi:latest"
             fi
           fi
-
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo $TAGS
+
+          # compute the marketplace dir
+          MARKETPLACE_DIR="/var/glpi/marketplace"
+          if [[ "$IMAGE_VERSION_MAJOR" = "10" ]]; then
+            MARKETPLACE_DIR="/var/www/glpi/marketplace"
+          fi
+          echo "marketplace_dir=$MARKETPLACE_DIR" >> $GITHUB_OUTPUT
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:
@@ -113,6 +119,7 @@ jobs:
           build-args: |
             BUILDER_IMAGE=php:${{inputs.php-version}}-cli-alpine
             APP_IMAGE=php:${{inputs.php-version}}-apache
+            GLPI_MARKETPLACE_DIR=${{ steps.variables.outputs.marketplace_dir }}
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
           context: "glpi"

--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -54,6 +54,8 @@ RUN /usr/src/glpi/tools/build_glpi.sh
 #####
 FROM $APP_IMAGE
 
+ARG GLPI_MARKETPLACE_DIR=/var/glpi/marketplace
+
 LABEL \
   org.opencontainers.image.title="GLPI nightly build" \
   org.opencontainers.image.description="This container contains Apache/PHP and a nightly build of GLPI. \
@@ -152,7 +154,7 @@ VOLUME /var/glpi
 ENV \
   GLPI_INSTALL_MODE=DOCKER \
   GLPI_CONFIG_DIR=/var/glpi/config \
-  GLPI_MARKETPLACE_DIR=/var/glpi/marketplace \
+  GLPI_MARKETPLACE_DIR=${GLPI_MARKETPLACE_DIR} \
   GLPI_VAR_DIR=/var/glpi/files \
   GLPI_LOG_DIR=/var/glpi/logs \
   GLPI_SKIP_AUTOINSTALL=false \

--- a/glpi/files/opt/glpi/permissions.sh
+++ b/glpi/files/opt/glpi/permissions.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-# get GLPI major version
-GLPI_MAJOR_VERSION=$(ls /var/www/glpi/version | sort -V | head -n 1 | cut -d. -f1)
-# fix marketplace directory for GLPI versions < 11
-if [ $GLPI_MAJOR_VERSION -lt 11 ]; then
-    GLPI_MARKETPLACE_DIR="/var/www/glpi/marketplace"
-fi
-
 # Create `config`, `marketplace` and `files` volume (sub)directories that are missing
 # and set ACL for www-data user
 dirs=(


### PR DESCRIPTION
As far as I understand, the redefinition of this env variable at runtime is not working since the scripts have been splitted between the `ENTRYPOINT` and the `CMD` instructions. Indeed, the variable is redefined only in the entrypoint context, and not in the apache execution context. Defining the crrect value at build time fixes this.

It fixes #183.