### PR TITLE
Migrate from Debian `bullseye` to `trixie`

### DIFF
--- a/.github/workflows/githubactions-php-apache.yml
+++ b/.github/workflows/githubactions-php-apache.yml
@@ -23,11 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {base-image: "php:8.1-apache-bullseye", php-version: "8.1"}
-          - {base-image: "php:8.2-apache-bullseye", php-version: "8.2"}
-          - {base-image: "php:8.3-apache-bullseye", php-version: "8.3"}
-          - {base-image: "php:8.4-apache-bullseye", php-version: "8.4"}
-          - {base-image: "php:8.5-rc-apache-bullseye", php-version: "8.5"}
+          - {base-image: "php:8.1-apache-trixie", php-version: "8.1"}
+          - {base-image: "php:8.2-apache-trixie", php-version: "8.2"}
+          - {base-image: "php:8.3-apache-trixie", php-version: "8.3"}
+          - {base-image: "php:8.4-apache-trixie", php-version: "8.4"}
+          - {base-image: "php:8.5-rc-apache-trixie", php-version: "8.5"}
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/githubactions-php.yml
+++ b/.github/workflows/githubactions-php.yml
@@ -23,11 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {base-image: "php:8.1-fpm-bullseye", php-version: "8.1"}
-          - {base-image: "php:8.2-fpm-bullseye", php-version: "8.2"}
-          - {base-image: "php:8.3-fpm-bullseye", php-version: "8.3"}
-          - {base-image: "php:8.4-fpm-bullseye", php-version: "8.4"}
-          - {base-image: "php:8.5-rc-fpm-bullseye", php-version: "8.5"}
+          - {base-image: "php:8.1-fpm-trixie", php-version: "8.1"}
+          - {base-image: "php:8.2-fpm-trixie", php-version: "8.2"}
+          - {base-image: "php:8.3-fpm-trixie", php-version: "8.3"}
+          - {base-image: "php:8.4-fpm-trixie", php-version: "8.4"}
+          - {base-image: "php:8.5-rc-fpm-trixie", php-version: "8.5"}
     steps:
       - name: "Set variables"
         run: |

--- a/.github/workflows/glpi-development-env.yml
+++ b/.github/workflows/glpi-development-env.yml
@@ -22,10 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
-        latest: ["false"]
         include:
-          - {php-version: "8.4", latest: "true"}
+          - {base-image: "php:7.4-apache-bullseye", php-version: "7.4", latest: "false"}
+          - {base-image: "php:8.0-apache-bullseye", php-version: "8.0", latest: "false"}
+          - {base-image: "php:8.1-apache-trixie", php-version: "8.1", latest: "false"}
+          - {base-image: "php:8.2-apache-trixie", php-version: "8.2", latest: "false"}
+          - {base-image: "php:8.3-apache-trixie", php-version: "8.3", latest: "false"}
+          - {base-image: "php:8.4-apache-trixie", php-version: "8.4", latest: "true"}
     steps:
       - name: "Set variables"
         run: |
@@ -53,7 +56,7 @@ jobs:
         uses: "docker/build-push-action@v6"
         with:
           build-args: |
-            BASE_IMAGE=php:${{ matrix.php-version }}-apache-bullseye
+            BASE_IMAGE=${{ matrix.base-image }}
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
           context: "glpi-development-env"

--- a/githubactions-dovecot/Dockerfile
+++ b/githubactions-dovecot/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 LABEL \
   org.opencontainers.image.title="GLPI Github Actions Dovecot container" \

--- a/githubactions-php-apache/Dockerfile
+++ b/githubactions-php-apache/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=php:apache-bullseye
+ARG BASE_IMAGE=php:apache-trixie
 
 
 #####

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=php:fpm-bullseye
+ARG BASE_IMAGE=php:fpm-trixie
 
 
 #####

--- a/glpi-development-env/Dockerfile
+++ b/glpi-development-env/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=php:apache-bullseye
+ARG BASE_IMAGE=php:apache-trixie
 
 
 #####


### PR DESCRIPTION
`bullseye` PHP images are not built anymore since https://github.com/docker-library/php/pull/1596. We have to move to a most recent version of Debian to be able to get latest PHP versions.

The PHP 8.5 builds are already failing, and will keep failing until a PHP 8.5 compatible release is made for both `redis` and `memcached` extensions.