### PR TITLE
Revert "Install latest gettext version"

### DIFF
--- a/githubactions-php-apache/Dockerfile
+++ b/githubactions-php-apache/Dockerfile
@@ -96,10 +96,7 @@ RUN \
   && apt install --assume-yes --no-install-recommends --quiet git unzip \
   \
   # Install gettext used for translation files.
-  && mkdir -p /tmp/gettext \
-  && (curl -LsfS https://ftp.gnu.org/pub/gnu/gettext/gettext-0.25.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/gettext" --strip 1) \
-  && (cd /tmp/gettext && ./configure && make && make install) \
-  && rm -rf /tmp/gettext \
+  && apt install --assume-yes --no-install-recommends --quiet gettext \
   \
   # Install Cypress dependencies
   && apt install --assume-yes --no-install-recommends --quiet libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb \

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -93,10 +93,7 @@ RUN \
   && apt install --assume-yes --no-install-recommends --quiet git unzip \
   \
   # Install gettext used for translation files.
-  && mkdir -p /tmp/gettext \
-  && (curl -LsfS https://ftp.gnu.org/pub/gnu/gettext/gettext-0.25.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/gettext" --strip 1) \
-  && (cd /tmp/gettext && ./configure && make && make install) \
-  && rm -rf /tmp/gettext \
+  && apt install --assume-yes --no-install-recommends --quiet gettext \
   \
   # Install Cypress dependencies
   && apt install --assume-yes --no-install-recommends --quiet libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
@@ -117,10 +114,6 @@ USER glpi
 VOLUME /home/glpi
 VOLUME /var/www/glpi
 WORKDIR /var/www/glpi
-
-# Define the library path where built gettext shared libraries are located
-ENV \
-  LD_LIBRARY_PATH="/usr/local/lib"
 
 # Define GLPI environment variables
 ENV \

--- a/glpi-development-env/Dockerfile
+++ b/glpi-development-env/Dockerfile
@@ -103,10 +103,7 @@ RUN apt update \
   && apt install --assume-yes --no-install-recommends --quiet git unzip \
   \
   # Install gettext used for translation files.
-  && mkdir -p /tmp/gettext \
-  && (curl -LsfS https://ftp.gnu.org/pub/gnu/gettext/gettext-0.25.tar.gz | tar --extract --ungzip --verbose --directory="/tmp/gettext" --strip 1) \
-  && (cd /tmp/gettext && ./configure && make && make install) \
-  && rm -rf /tmp/gettext \
+  && apt install --assume-yes --no-install-recommends --quiet gettext \
   \
   # Install Cypress dependencies
   && apt install --assume-yes --no-install-recommends --quiet libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb \


### PR DESCRIPTION
This reverts commit 8ac61feeb4be2750aa9e41599003da88c6f9d530.

We are now using Debian Trixie in our images. The `gettext` package in this Debian version is 0.23.1 (see https://packages.debian.org/trixie/gettext) and therefore includes the `gettext` changes we wanted to get in our images:
 - warnings related to a mix between singular and pluralized messages (e.g. `__('Comment')` VS `_n('Comment', 'Comments', $count)`
 - compatibility with indented HEREDOC/NOWDOC closing marker.

There is no need to manually build the 0.25 version anymore. It will drastically reduce the image build time.