### PR TITLE
Do not remove `npm` deps from the `githubactions-glpi-apache` image

### DIFF
--- a/githubactions-glpi-apache/Dockerfile
+++ b/githubactions-glpi-apache/Dockerfile
@@ -19,5 +19,4 @@ RUN \
   && composer --working-dir=/var/www/glpi build \
   \
   # Clean useless files
-  && rm -rf /tmp/glpi \
-  && rm -rf /var/www/glpi/node_modules
+  && rm -rf /tmp/glpi


### PR DESCRIPTION
Removing them prevent plugins from executing tools like `eslint` using the version provided by GLPI.

The image size will probably increase a lot.

Another solution would be to run the GLPI `build` in each job, using the Github Actions cache to not have to download dependencies each time, but it would still require to take some time to build the GLPI vue components and the locales files.