### PR TITLE
Optimize GLPI initialization script to remove redundant operations

### DIFF
--- a/glpi/files/opt/glpi/entrypoint/init-volumes-directories.sh
+++ b/glpi/files/opt/glpi/entrypoint/init-volumes-directories.sh
@@ -3,9 +3,13 @@ set -e -u -o pipefail
 
 # Create `config`, `marketplace` and `files` volume (sub)directories that are missing
 # and set ACL for www-data user
-dirs=(
+roots=(
     "${GLPI_CONFIG_DIR}"
     "${GLPI_VAR_DIR}"
+    "${GLPI_MARKETPLACE_DIR}"
+    "${GLPI_LOG_DIR}"
+)
+vars=(
     "${GLPI_VAR_DIR}/_cache"
     "${GLPI_VAR_DIR}/_cron"
     "${GLPI_VAR_DIR}/_dumps"
@@ -19,19 +23,18 @@ dirs=(
     "${GLPI_VAR_DIR}/_tmp"
     "${GLPI_VAR_DIR}/_uploads"
     "${GLPI_VAR_DIR}/_inventories"
-    "${GLPI_MARKETPLACE_DIR}"
-    "${GLPI_LOG_DIR}"
 )
-for dir in "${dirs[@]}"
+all_dirs=("${roots[@]}" "${vars[@]}")
+for dir in "${all_dirs[@]}"
 do
-    if [ ! -d "$dir" ]
-    then
-        echo "Creating $dir..."
-        mkdir "$dir"
-    fi
+    echo "Creating $dir if does not exists..."
+    mkdir -p -- "$dir"
+done
+
+for dir in "${roots[@]}"
+do
     echo "Setting $dir ACLs..."
-    chown -R www-data:www-data "$dir"
-    chmod u+rwx "$dir"
-    find "$dir" -type d -exec chmod u+rwx {} \;
-    find "$dir" -type f -exec chmod u+rw {} \;
+    chown -R -- www-data:www-data "$dir"
+    find "$dir" -type d -exec chmod u+rwx {} +
+    find "$dir" -type f -exec chmod u+rw {} +
 done


### PR DESCRIPTION
This change optimizes the GLPI initialization script by eliminating redundant directory and permission operations.
The script now creates all required directories only once, applies permissions efficiently at the root level, and ensures consistent ownership for the www-data user.
It remains fully idempotent and includes safer path handling using -- to prevent option parsing issues.