### PR TITLE
Bump node to v22

### DIFF
--- a/githubactions-php-apache/Dockerfile
+++ b/githubactions-php-apache/Dockerfile
@@ -88,7 +88,7 @@ RUN \
   && apt install --assume-yes --no-install-recommends --quiet gnupg \
   && mkdir -p /etc/apt/keyrings \
   && curl --fail --silent --show-error --location https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor --output /etc/apt/keyrings/nodesource.gpg \
-  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
   && apt update \
   && apt install --assume-yes --no-install-recommends --quiet nodejs \
   \


### PR DESCRIPTION
Node 22 is required for Vite (https://github.com/glpi-project/glpi/pull/22356), but also v20 is currently in maintenance-only mode until April 2026. v22 will be in maintenance mode until 2027.