### PR TITLE
Fix `GLPI_*` env vars in auto-install

### DIFF
--- a/glpi/files/opt/glpi/startup.sh
+++ b/glpi/files/opt/glpi/startup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e -u -o pipefail
 
+/opt/glpi/startup/init-env.sh
 /opt/glpi/startup/install.sh
 /opt/glpi/startup/start.sh

--- a/glpi/files/opt/glpi/startup/init-env.sh
+++ b/glpi/files/opt/glpi/startup/init-env.sh
@@ -1,0 +1,3 @@
+# Copy the GLPI env variables to `/etc/environment`, to make them available for the commands executed by the cron service
+# using the `www-data` user.
+printenv | grep 'GLPI_' > /etc/environment

--- a/glpi/files/opt/glpi/startup/start.sh
+++ b/glpi/files/opt/glpi/startup/start.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-# Copy the GLPI env variables to `/etc/environment`, to make them available for the commands executed by the cron service
-# using the `www-data` user.
-printenv | grep 'GLPI_' > /etc/environment
-
 # Run cron service.
 cron
 


### PR DESCRIPTION
Follows #238.

The env variables must be defined before the autoinstall/autoupdate process.