### PR TITLE
Patch GLPI composer config to be able to rebuild GLPI 11.0.4

### DIFF
--- a/.github/workflows/glpi.yml
+++ b/.github/workflows/glpi.yml
@@ -100,6 +100,8 @@ jobs:
           curl https://github.com/glpi-project/glpi/archive/${{ inputs.glpi-version }}.tar.gz --location --output glpi.tar.gz
           mkdir glpi/sources
           tar --extract --ungzip --strip 1 --file glpi.tar.gz --directory glpi/sources
+          curl https://patch-diff.githubusercontent.com/raw/glpi-project/glpi/pull/22381.diff --location --output composer-audit-config.diff
+          patch --force --directory=glpi/sources < composer-audit-config.diff
       - name: "Set up QEMU"
         uses: "docker/setup-qemu-action@v3"
       - name: "Set up Docker Buildx"


### PR DESCRIPTION
This should permit to bypass the following error that prevent to rebuild GLPI 11.0.x images:

```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

Problem 1
  - Root composer.json requires altcha-org/altcha == 1.1.2.0 (exact version match), found altcha-org/altcha[v1.1.2] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-5rb8-j658-qvzz") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

This patch will have to be removed once GLPI 11.0.5 will be released.