### PR TITLE
Adapt workflow run name to the built version

### DIFF
--- a/.github/workflows/glpi.yml
+++ b/.github/workflows/glpi.yml
@@ -1,5 +1,5 @@
 name: "GLPI Docker Images"
-run-name: "GLPI Docker Images (${{ inputs.glpi-version || github.event.pull_request.title || github.event.head_commit.message || github.sha }})"
+run-name: "GLPI Docker Images (${{ inputs.glpi-version || (github.event.pull_request.number && format('#{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)) || github.event.head_commit.message || github.sha }})"
 
 # Unified workflow for building GLPI Docker images
 # - workflow_call: Called by GLPI repo for releases and nightly builds


### PR DESCRIPTION
It will be easier to find a workflow run corresponding to a given GLPI version.

Before:
<img width="558" height="225" alt="image" src="https://github.com/user-attachments/assets/983c7303-2c18-47a5-9fa6-f22dfd016165" />

After:
<img width="567" height="143" alt="image" src="https://github.com/user-attachments/assets/2cc3fe01-9003-46b1-9da0-75eeb21ff469" />
