### PR TITLE
Disable docker/github login if push is not set

### DIFF
--- a/.github/workflows/glpi.yml
+++ b/.github/workflows/glpi.yml
@@ -290,7 +290,6 @@ jobs:
           labels: "${{ steps.meta.outputs.labels }}"
           platforms: "${{ matrix.platform.arch }}"
           pull: true
-          push: ${{ needs.prepare.outputs.push == 'true' }}
           sbom: ${{ needs.prepare.outputs.push == 'true' }}
           provenance: ${{ needs.prepare.outputs.push == 'true' && 'mode=max' || 'false' }}
           outputs: "type=image,\"name=${{ env.DOCKERHUB_IMAGE }},${{ env.GHCR_IMAGE }}\",push-by-digest=true,name-canonical=true,push=${{ needs.prepare.outputs.push }}"


### PR DESCRIPTION
Disable docker/GitHub login if push is not set (allow external PR to be tested as no push is enabled)