### PR TITLE
feat: add Docker secrets support for sensitive env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains build files for docker images available in [Github Cont
 ## Summary
 
 - [How to use this image](#how-to-use-this-image)
+- [Docker Secrets](#docker-secrets)
 - [Timezones support](#timezones-support)
 - [Volumes](#volumes)
 - [Custom PHP configuration](#custom-php-configuration)
@@ -97,6 +98,77 @@ If so, when accessing the web interface, installation wizard will ask you to pro
 - Database: `glpi`
 - User: `glpi`
 - Password: `glpi`
+
+### Docker Secrets
+
+For improved security, sensitive environment variables can be loaded from files instead of being passed directly. This follows the `_FILE` convention used by official Docker images (MySQL, MariaDB, PostgreSQL).
+
+The following variables support the `_FILE` suffix:
+
+| Variable | `_FILE` variant | Description |
+|:---------|:----------------|:------------|
+| `GLPI_DB_HOST` | `GLPI_DB_HOST_FILE` | Database hostname |
+| `GLPI_DB_PORT` | `GLPI_DB_PORT_FILE` | Database port |
+| `GLPI_DB_NAME` | `GLPI_DB_NAME_FILE` | Database name |
+| `GLPI_DB_USER` | `GLPI_DB_USER_FILE` | Database user |
+| `GLPI_DB_PASSWORD` | `GLPI_DB_PASSWORD_FILE` | Database password |
+
+The resolution order is:
+1. `VAR_FILE` — reads the content of the file pointed to by the variable
+2. `/run/secrets/VAR` — automatic detection of Docker Swarm / Kubernetes / Podman secrets
+3. `VAR` — standard environment variable (default behavior)
+
+> **Note:** Setting both `VAR` and `VAR_FILE` at the same time will result in an error.
+
+#### Example with Docker Compose
+
+1. Create a file containing your database password:
+
+   ```bash
+   echo "my_secure_password" > ./db_password.txt
+   ```
+
+2. Reference it in your `docker-compose.yml`:
+
+   ```yaml
+   services:
+     glpi:
+       image: "glpi/glpi:latest"
+       environment:
+         GLPI_DB_HOST: db
+         GLPI_DB_PORT: 3306
+         GLPI_DB_NAME: glpi
+         GLPI_DB_USER: glpi
+         GLPI_DB_PASSWORD_FILE: /run/secrets/db_password
+       volumes:
+         - glpi_data:/var/glpi
+         - ./db_password.txt:/run/secrets/db_password:ro
+       depends_on:
+         - db
+       ports:
+         - "80:80"
+   ```
+
+#### Example with Docker Swarm
+
+```yaml
+services:
+  glpi:
+    image: "glpi/glpi:latest"
+    secrets:
+      - db_password
+    environment:
+      GLPI_DB_HOST: db
+      GLPI_DB_PORT: 3306
+      GLPI_DB_NAME: glpi
+      GLPI_DB_USER: glpi
+      # No need to set GLPI_DB_PASSWORD or GLPI_DB_PASSWORD_FILE.
+      # The secret is automatically detected at /run/secrets/GLPI_DB_PASSWORD.
+
+secrets:
+  db_password:
+    file: ./db_password.txt
+```
 
 ### Timezones support
 

--- a/glpi/files/opt/glpi/entrypoint.sh
+++ b/glpi/files/opt/glpi/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e -u -o pipefail
 
+# Load secrets from files (_FILE suffix, /run/secrets/, etc.)
+source /opt/glpi/entrypoint/load-secrets.sh
 
 /opt/glpi/entrypoint/init-volumes-directories.sh
 /opt/glpi/entrypoint/forward-logs.sh

--- a/glpi/files/opt/glpi/entrypoint/load-secrets.sh
+++ b/glpi/files/opt/glpi/entrypoint/load-secrets.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e -u -o pipefail
+
+# Docker secrets support for GLPI
+# Resolves sensitive environment variables from files (Docker secrets, Kubernetes secrets, or _FILE suffix).
+#
+# Priority order:
+#   1. VAR_FILE environment variable (points to a file containing the value)
+#   2. /run/secrets/VAR file (Docker Swarm / Kubernetes / Podman)
+#   3. Existing environment variable value (default behavior)
+
+# file_env - Read an environment variable from a file, following the Docker _FILE convention.
+# Usage: file_env VAR [DEFAULT]
+#
+# Based on the pattern used by official Docker images (mysql, mariadb, postgres).
+file_env() {
+    local var="$1"
+    local default="${2:-}"
+
+    local file_var="${var}_FILE"
+    local val="$default"
+
+    # Get current values
+    local current_val="${!var:-}"
+    local file_val="${!file_var:-}"
+
+    if [ -n "$current_val" ] && [ -n "$file_val" ]; then
+        echo "ERROR: Both $var and $file_var are set. These are mutually exclusive."
+        exit 1
+    fi
+
+    if [ -n "$file_val" ]; then
+        # _FILE variable is set, read from the specified file
+        if [ ! -f "$file_val" ]; then
+            echo "ERROR: Secret file '$file_val' specified in $file_var does not exist."
+            exit 1
+        fi
+        if [ ! -r "$file_val" ]; then
+            echo "ERROR: Secret file '$file_val' specified in $file_var is not readable."
+            exit 1
+        fi
+        val="$(< "$file_val")"
+        unset "$file_var"
+    elif [ -f "/run/secrets/$var" ]; then
+        # Docker Swarm / Kubernetes / Podman secret
+        val="$(< "/run/secrets/$var")"
+    elif [ -n "$current_val" ]; then
+        # Use existing environment variable
+        val="$current_val"
+    fi
+
+    export "$var"="$val"
+}
+
+# List of environment variables that support secret file resolution
+secret_vars=(
+    GLPI_DB_HOST
+    GLPI_DB_PORT
+    GLPI_DB_NAME
+    GLPI_DB_USER
+    GLPI_DB_PASSWORD
+)
+
+for var in "${secret_vars[@]}"; do
+    file_env "$var"
+done


### PR DESCRIPTION
## Summary

- Add `_FILE` suffix convention for sensitive environment variables (`GLPI_DB_PASSWORD_FILE`, `GLPI_DB_USER_FILE`, etc.)
- Auto-detect secrets from `/run/secrets/` (Docker Swarm, Kubernetes, Podman)
- Fallback to standard environment variables for backward compatibility
- Error handling for conflicts (both `VAR` and `VAR_FILE` set) and missing files

Follows the standard pattern used by official Docker images (MySQL, MariaDB, PostgreSQL), as discussed in #194.

## Changes

| File | Description |
|------|-------------|
| `glpi/files/opt/glpi/entrypoint/load-secrets.sh` | New script with `file_env()` function for secret resolution |
| `glpi/files/opt/glpi/entrypoint.sh` | Source `load-secrets.sh` before other entrypoint scripts |
| `README.md` | Documentation with examples for Docker Compose and Docker Swarm |

## Resolution order

1. `VAR_FILE` — reads content from the file path specified
2. `/run/secrets/VAR` — auto-detection of Docker Swarm / Kubernetes / Podman secrets
3. `VAR` — standard environment variable (existing behavior, no breaking change)

## Test plan

- [x] Env var fallback works (existing behavior preserved)
- [x] `_FILE` variable reads content from file and unsets `_FILE` var
- [x] Conflict detection: error when both `VAR` and `VAR_FILE` are set
- [x] Missing file detection: error with clear message when file doesn't exist
- [x] Docker image builds successfully

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)