### PR TITLE
docs: comprehensive README rewrite and technical architecture reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A few links:
 
 - [Report an issue](https://github.com/glpi-project/glpi/issues/new?template=bug_report.yml)
 - [Documentation](https://glpi-project.org/documentation/)
+- [Technical Architecture](docs/architecture.md)
 - [Contributing](CONTRIBUTING.md)
 
 
@@ -17,14 +18,21 @@ This repository contains build files for docker images available in [Github Cont
 
 ## Summary
 
-- [How to use this image](#how-to-use-this-image)
-- [Timezones support](#timezones-support)
-- [Volumes](#volumes)
-- [Custom PHP configuration](#custom-php-configuration)
-- [Managing Cron tasks](#managing-cron-tasks)
-- [Adding custom Cron tasks](#adding-custom-cron-tasks)
+- [Quick Start](#quick-start)
+- [Image Architecture](#image-architecture)
+- [Environment Variables](#environment-variables)
+- [Volumes and Data Persistence](#volumes-and-data-persistence)
+- [Timezones Support](#timezones-support)
+- [Custom PHP Configuration](#custom-php-configuration)
+- [Custom Apache Configuration](#custom-apache-configuration)
+- [Managing Cron Tasks](#managing-cron-tasks)
+- [Adding Custom Scheduled Jobs](#adding-custom-scheduled-jobs)
+- [Reverse Proxy and HTTPS](#reverse-proxy-and-https)
+- [Upgrading](#upgrading)
+- [Multi-Architecture Support](#multi-architecture-support)
+- [Troubleshooting](#troubleshooting)
 
-## How to use this image
+## Quick Start
 
 ### via [docker compose](https://github.com/docker/compose)
 
@@ -37,18 +45,15 @@ services:
     image: "glpi/glpi:latest"
     restart: "unless-stopped"
     volumes:
-       # Using a named volume avoids permission issues on host (automatically managed by Docker)
        - glpi_data:/var/glpi
-      # For GLPI 10.x, uncomment the following line to create a volume for plugins fetched from the marketplace.
-      # - "./storage/glpi_marketplace:/var/www/glpi/marketplace/:rw"
-    env_file: .env # Pass environment variables from .env file to the container
+    env_file: .env
     depends_on:
       - db
     ports:
       - "80:80"
 
   db:
-    image: "mysql"
+    image: "mariadb:11"
     restart: "unless-stopped"
     volumes:
        - db_data:/var/lib/mysql
@@ -63,106 +68,534 @@ volumes:
    db_data:
 ```
 
-And an .env file:
-
 **.env**
 ```env
 GLPI_DB_HOST=db
 GLPI_DB_PORT=3306
 GLPI_DB_NAME=glpi
 GLPI_DB_USER=glpi
-GLPI_DB_PASSWORD=glpi
+GLPI_DB_PASSWORD=change_me_to_a_secure_password
 ```
 
-Then launch it with:
+Then launch it:
 
 ```bash
 docker compose up -d
 ```
 
-Please note that we setup a random root password for the MySQL database, so you will need to check the logs of the `db` container to find it:
+Once the containers are running, access GLPI at `http://localhost`. GLPI will automatically install itself on first run.
 
-```bash
-docker logs <db_container_id>
+Default GLPI credentials after auto-install:
+- **Username:** `glpi`
+- **Password:** `glpi`
+
+> **Important:** Change these default credentials immediately after your first login.
+
+## Image Architecture
+
+### How the Image Works
+
+The GLPI Docker image is built in three stages:
+
+1. **Downloader** — Fetches the GLPI source code from GitHub
+2. **Builder** — Installs dependencies (Composer, npm) and compiles the application
+3. **Application** — Final runtime image with Apache, PHP, and Supervisor
+
+At container startup, the entrypoint runs the following scripts in order:
+
+| Step | Script | Description |
+|:-----|:-------|:------------|
+| 1 | `init-volumes-directories.sh` | Creates required directories and checks permissions |
+| 2 | `forward-logs.sh` | Tails GLPI logs to container stdout/stderr |
+| 3 | `wait-for-db.sh` | Waits up to 120s for the database to become available |
+| 4 | `install.sh` | Auto-installs or auto-updates GLPI if enabled |
+
+After the entrypoint completes, **Supervisor** takes over and manages two processes:
+- **Apache** — serves the GLPI web application
+- **GLPI Cron Worker** — executes background tasks every 60 seconds
+
+### PHP Extensions Included
+
+The image ships with the following PHP extensions pre-installed:
+
+| Extension | Purpose |
+|:----------|:--------|
+| apcu | In-memory object caching |
+| bcmath | Arbitrary precision math |
+| bz2 | Bzip2 compression |
+| exif | Image metadata reading |
+| gd | Image processing (with FreeType and JPEG) |
+| intl | Internationalization (ICU) |
+| ldap | LDAP/Active Directory authentication |
+| mysqli | MySQL/MariaDB database driver |
+| opcache | PHP bytecode caching |
+| redis | Redis session/cache backend |
+| soap | SOAP protocol support (used by some plugins) |
+| zip | ZIP archive handling |
+
+### Apache Configuration
+
+- **DocumentRoot:** `/var/www/glpi/public`
+- **Module enabled:** `mod_rewrite`
+- **Security hardening:** `ServerTokens Prod`, `ServerSignature Off`, `expose_php = off`
+- **Bearer tokens:** HTTP Authorization header is preserved for API access
+
+### Security Features
+
+- Container runs as non-root user (`www-data`)
+- Apache binds to port 80 via `setcap` (no root required)
+- PHP uses `php.ini-production` configuration
+- Session cookies are set to `HttpOnly` and `SameSite=Strict`
+- PHP version is not exposed in HTTP headers
+
+## Environment Variables
+
+### Database Configuration
+
+| Variable | Required | Description |
+|:---------|:---------|:------------|
+| `GLPI_DB_HOST` | Yes | Database server hostname |
+| `GLPI_DB_PORT` | Yes | Database server port (typically `3306`) |
+| `GLPI_DB_NAME` | Yes | Database name |
+| `GLPI_DB_USER` | Yes | Database user |
+| `GLPI_DB_PASSWORD` | Yes | Database password |
+
+> All five variables must be set for auto-install and auto-update to work. If any is missing, both features are automatically disabled.
+
+### Installation Control
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `GLPI_SKIP_AUTOINSTALL` | `false` | Set to `true` to skip automatic database installation on first run |
+| `GLPI_SKIP_AUTOUPDATE` | `false` | Set to `true` to skip automatic database updates on container restart |
+
+When auto-install is disabled, the GLPI web wizard will guide you through the installation process manually.
+
+### Cron Control
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `GLPI_CRONTAB_ENABLED` | `1` | Set to `0` to disable the background cron worker |
+
+### Path Configuration
+
+These are set automatically and generally do not need to be changed:
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `GLPI_CONFIG_DIR` | `/var/glpi/config` | GLPI configuration directory |
+| `GLPI_VAR_DIR` | `/var/glpi/files` | GLPI data files directory |
+| `GLPI_LOG_DIR` | `/var/glpi/logs` | GLPI log files directory |
+| `GLPI_MARKETPLACE_DIR` | `/var/glpi/marketplace` | Plugin marketplace directory |
+| `GLPI_INSTALL_MODE` | `DOCKER` | Installation mode identifier |
+
+## Volumes and Data Persistence
+
+The image declares a single volume at `/var/glpi` that contains all persistent data:
+
+```
+/var/glpi/
+├── config/          # GLPI configuration (config_db.php, etc.)
+├── files/           # Application data
+│   ├── _cache/      # Application cache
+│   ├── _cron/       # Cron task state
+│   ├── _dumps/      # Database dumps
+│   ├── _graphs/     # Generated graphs
+│   ├── _locales/    # Translation files
+│   ├── _lock/       # Lock files
+│   ├── _pictures/   # Uploaded images
+│   ├── _plugins/    # Plugin data
+│   ├── _rss/        # RSS cache
+│   ├── _sessions/   # PHP session files
+│   ├── _tmp/        # Temporary files
+│   ├── _uploads/    # User uploads
+│   └── _inventories/# Inventory data
+├── marketplace/     # Plugins installed from marketplace
+└── logs/            # Application logs
 ```
 
-Once the containers are running, you can access GLPI at `http://localhost`
-GLPI will automatically install or update itself if needed.
+### Recommended Volume Setup
 
-You can disable this behavior by setting the environment variable `GLPI_SKIP_AUTOINSTALL` to `true` in the `.env` file. Same with `GLPI_SKIP_AUTOUPDATE` to disable automatic updates.
+Use **named volumes** (managed by Docker) to avoid permission issues:
 
-If so, when accessing the web interface, installation wizard will ask you to provide the database connection details. You can use the following credentials:
-
-- Hostname: `db`
-- Database: `glpi`
-- User: `glpi`
-- Password: `glpi`
-
-### Timezones support
-
-If you want to initialize the timezones support for GLPI, we need to first GRANT the glpi user to access the `mysql.time_zone` table. So with the docker container running, you can run the following command:
-
-```bash
-docker exec -it <db_container_id> mysql -u root -p -e "GRANT SELECT ON mysql.time_zone_name TO 'glpi'@'%';FLUSH PRIVILEGES;"
-```
-The root password will be the one you found in the logs of the `db` container previously.
-
-Then you can run the following command to initialize the timezones on the GLPI container:
-
-```bash
-docker exec -it <glpi_container_id> /var/www/glpi/bin/console database:enable_timezones
+```yaml
+volumes:
+  - glpi_data:/var/glpi
 ```
 
-### Volumes
+If you prefer **bind mounts**, make sure the host directory is writable by UID 33 (`www-data`):
 
-By default, the `glpi/glpi` image provides a volume containing its `config`, `marketplace` and `files` directories.
+```bash
+mkdir -p ./glpi_data
+chown -R 33:33 ./glpi_data
+```
 
-For GLPI 10.0.x version the marketplace directory is not declared in the volume as the path differs. You may want to create a manual volume for the path `/var/www/glpi/marketplace` if you plan to use it.  
-If you are building your own GLPI 10.0.x image using the `glpi/Dockerfile` file, you have to specify the marketplace path using the `--build-arg GLPI_MARKETPLACE_DIR=/var/www/glpi/marketplace` option.
+```yaml
+volumes:
+  - ./glpi_data:/var/glpi
+```
 
-You can also mount a volume containing your own custom plugins in `/var/www/glpi/plugins`.
+### Custom Plugins Volume
 
-### Custom PHP configuration
-The following example sets the memory limit to 256M
+You can mount your own plugins directory:
 
-1. Create an ini file  
-   **custom-config.ini**
-   ```ini
-   memory_limit = 256M
-   ```
-2. Update the volumes configuration
+```yaml
+volumes:
+  - ./my_plugins:/var/www/glpi/plugins:ro
+```
 
+### GLPI 10.x Marketplace Path
+
+For GLPI 10.0.x, the marketplace uses a different path. You need to:
+
+1. Add a separate volume:
    ```yaml
    volumes:
-     - "./custom-config.ini:/usr/local/etc/php/conf.d/custom-config.ini:ro"
+     - glpi_marketplace:/var/www/glpi/marketplace
+   ```
+2. If building your own image, use:
+   ```bash
+   docker build --build-arg GLPI_MARKETPLACE_DIR=/var/www/glpi/marketplace glpi/
    ```
 
-3. Apply the changes
+## Timezones Support
 
+To enable timezone support in GLPI:
+
+1. Grant the GLPI database user access to the timezone table:
+   ```bash
+   docker exec -it <db_container_id> mysql -u root -p \
+     -e "GRANT SELECT ON mysql.time_zone_name TO 'glpi'@'%'; FLUSH PRIVILEGES;"
+   ```
+   > The root password can be found in the database container logs: `docker logs <db_container_id>`
+
+2. Initialize the timezones in the GLPI container:
+   ```bash
+   docker exec -it <glpi_container_id> php bin/console database:enable_timezones
+   ```
+
+## Custom PHP Configuration
+
+Mount a custom `.ini` file to override PHP settings.
+
+**Example: Increase memory limit to 256M**
+
+1. Create `custom-php.ini`:
+   ```ini
+   memory_limit = 256M
+   upload_max_filesize = 50M
+   post_max_size = 50M
+   max_execution_time = 300
+   ```
+
+2. Mount it in your `docker-compose.yml`:
+   ```yaml
+   volumes:
+     - ./custom-php.ini:/usr/local/etc/php/conf.d/custom-php.ini:ro
+   ```
+
+3. Restart the container:
    ```bash
    docker compose up -d
    ```
 
-4. Check the configuration by running on the GLPI container:
-
+4. Verify:
    ```bash
-   docker compose exec glpi sh -c 'php -r "phpinfo();" | grep memory_limit'
+   docker compose exec glpi php -r "echo ini_get('memory_limit');"
+   ```
+   Or check from the GLPI web interface under `Setup > General > System > Server`.
+
+### Default PHP Settings
+
+The image uses `php.ini-production` with these additional settings:
+
+| Setting | Value | Description |
+|:--------|:------|:------------|
+| `session.cookie_httponly` | `on` | Cookies not accessible via JavaScript |
+| `session.cookie_samesite` | `Strict` | Cookies only sent to same origin |
+| `expose_php` | `off` | PHP version hidden from headers |
+| `session.gc_probability` | `1` | Session garbage collection enabled |
+| `session.gc_divisor` | `100` | GC runs on ~1% of requests |
+| `session.gc_maxlifetime` | `60480` | Session lifetime (~16.8 hours) |
+
+## Custom Apache Configuration
+
+To add custom Apache configuration, mount a `.conf` file:
+
+```yaml
+volumes:
+  - ./my-apache.conf:/etc/apache2/conf-available/zzz-custom.conf:ro
+```
+
+Then enable it:
+```bash
+docker compose exec glpi a2enconf zzz-custom
+docker compose exec glpi apachectl graceful
+```
+
+Or build a custom image with your config baked in.
+
+## Managing Cron Tasks
+
+By default, the image includes a background worker that executes GLPI cron tasks every 60 seconds. This is managed by Supervisor.
+
+### Disabling the Cron Worker
+
+Set `GLPI_CRONTAB_ENABLED=0` in your environment to disable it.
+
+This is useful for:
+- **Horizontal scaling** — run cron on a dedicated container while web nodes serve requests only
+- **Kubernetes deployments** — use a dedicated CronJob resource instead
+
+**Example: Dedicated cron container**
+```yaml
+services:
+  glpi-web:
+    image: "glpi/glpi:latest"
+    environment:
+      GLPI_CRONTAB_ENABLED: 0
+    # ... web-only instance
+
+  glpi-cron:
+    image: "glpi/glpi:latest"
+    environment:
+      GLPI_CRONTAB_ENABLED: 1
+    # ... cron-only instance, no ports exposed
+```
+
+## Adding Custom Scheduled Jobs
+
+Since the container runs as non-root (`www-data`), traditional cron is not available. Instead, use the built-in scheduler script with Supervisor.
+
+The scheduler supports two modes:
+
+| Mode | Behavior |
+|:-----|:---------|
+| `--interval <seconds>` | Runs immediately, then repeats every N seconds |
+| `--daily <HH:MM>` | Waits until the specified time, then repeats daily |
+
+### Options
+
+| Flag | Description |
+|:-----|:------------|
+| `--interval <seconds>` | Interval between runs |
+| `--daily <HH:MM>` | Time of day to run (24h format) |
+| `--name <name>` | Name displayed in logs |
+| `--no-wait-for-db` | Skip waiting for database availability |
+
+### Example: LDAP Sync Every 6 Hours
+
+Create `ldap-sync.conf`:
+```ini
+[program:ldap-sync]
+command = /opt/glpi/scheduler.sh --interval 21600 --name "LDAP Sync" -- php /var/www/glpi/bin/console ldap:synchronize_users
+autorestart = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
+```
+
+Mount it:
+```yaml
+volumes:
+  - ./ldap-sync.conf:/etc/supervisor/conf.d/ldap-sync.conf:ro
+```
+
+### Example: Daily Database Backup at 2 AM
+
+Create `backup.conf`:
+```ini
+[program:daily-backup]
+command = /opt/glpi/scheduler.sh --daily 02:00 --name "Daily Backup" -- /opt/glpi/scripts/backup.sh
+autorestart = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
+```
+
+See the [full scheduler documentation](docs/custom-cron-tasks.md) for more examples.
+
+## Reverse Proxy and HTTPS
+
+The GLPI image exposes only HTTP on port 80. For production use, place it behind a reverse proxy that handles TLS termination.
+
+### Example: Nginx Reverse Proxy
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name glpi.example.com;
+
+    ssl_certificate /etc/ssl/certs/glpi.crt;
+    ssl_certificate_key /etc/ssl/private/glpi.key;
+
+    location / {
+        proxy_pass http://glpi:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Example: Traefik
+
+```yaml
+services:
+  glpi:
+    image: "glpi/glpi:latest"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.glpi.rule=Host(`glpi.example.com`)"
+      - "traefik.http.routers.glpi.entrypoints=websecure"
+      - "traefik.http.routers.glpi.tls.certresolver=letsencrypt"
+      - "traefik.http.services.glpi.loadbalancer.server.port=80"
+```
+
+## Upgrading
+
+### Automatic Upgrades
+
+By default, the image will automatically update the GLPI database schema when a new version is deployed. This is controlled by `GLPI_SKIP_AUTOUPDATE`.
+
+To upgrade GLPI:
+
+1. **Backup your data:**
+   ```bash
+   docker compose exec db mysqldump -u root -p glpi > backup.sql
    ```
 
-   Or by browsing the GLPI website under `Setup > General > System > Server`.
+2. **Pull the new image:**
+   ```bash
+   docker compose pull glpi
+   ```
 
-### Managing Cron tasks
+3. **Restart the container:**
+   ```bash
+   docker compose up -d
+   ```
 
-By default, the image includes a background worker that executes GLPI cron tasks every minute. This behavior is controlled by the `GLPI_CRONTAB_ENABLED` environment variable.
+The database migration will run automatically on startup.
 
-This is especially useful for horizontal scaling or Kubernetes deployments, where you might want a dedicated container for cron tasks while disabling it on Web or API nodes to avoid automatic tasks duplication.
+### Manual Upgrades
 
-| Variable               | Default | Description                                                  |
-|:-----------------------|:--------|:-------------------------------------------------------------|
-| `GLPI_CRONTAB_ENABLED` | `1`     | Set to `1` to run the cron worker. Set to `0` to disable it. |
+If you prefer manual control (`GLPI_SKIP_AUTOUPDATE=true`):
 
-### Adding custom Cron tasks
+```bash
+docker compose exec glpi php bin/console database:update
+```
 
-Since the container runs as the non-root `www-data` user, traditional cron is not available. Instead, this image provides a built-in scheduler script that supports interval-based and daily scheduled tasks through supervisord.
+## Multi-Architecture Support
 
-See the [custom scheduled jobs documentation](docs/custom-cron-tasks.md) for usage examples.
+The image is built for both `linux/amd64` and `linux/arm64` platforms. Multi-arch manifests are pushed to both Docker Hub and GitHub Container Registry.
+
+### Available Registries
+
+| Registry | Image |
+|:---------|:------|
+| Docker Hub | `glpi/glpi` |
+| GitHub Container Registry | `ghcr.io/glpi-project/glpi` |
+
+### Tags
+
+| Tag | Description |
+|:----|:------------|
+| `latest` | Latest stable release |
+| `11.0.4` | Specific version |
+| `11` | Latest patch for major version 11 |
+
+## Troubleshooting
+
+### Container Logs
+
+GLPI logs are forwarded to Docker's logging system:
+
+```bash
+# All logs
+docker compose logs glpi
+
+# Follow logs in real time
+docker compose logs -f glpi
+```
+
+The following GLPI log files are streamed:
+
+| Log File | Stream | Content |
+|:---------|:-------|:--------|
+| `event.log` | stdout | Application events |
+| `cron.log` | stdout | Cron task execution |
+| `mail.log` | stdout | Mail operations |
+| `php-errors.log` | stderr | PHP errors |
+| `sql-errors.log` | stderr | Database errors |
+| `mail-errors.log` | stderr | Mail errors |
+| `access-errors.log` | stderr | Access errors |
+
+### Database Connection Issues
+
+If GLPI cannot connect to the database:
+
+1. Verify the database container is running:
+   ```bash
+   docker compose ps db
+   ```
+
+2. Check database logs:
+   ```bash
+   docker compose logs db
+   ```
+
+3. Test connectivity manually:
+   ```bash
+   docker compose exec glpi php -r "\$c = new mysqli('db','glpi','glpi','glpi',3306); echo \$c->connect_error ?: 'OK';"
+   ```
+
+The GLPI container waits up to **120 seconds** for the database to become available before giving up.
+
+### Permission Errors
+
+If you see errors like `Directory /var/glpi/... is not writable`:
+
+- **Named volumes:** Docker handles permissions automatically (recommended)
+- **Bind mounts:** Ensure the host directory is owned by UID 33 (`www-data`):
+  ```bash
+  sudo chown -R 33:33 /path/to/your/glpi_data
+  ```
+
+### Checking PHP Configuration
+
+```bash
+# Check a specific setting
+docker compose exec glpi php -r "echo ini_get('memory_limit');"
+
+# Full PHP info
+docker compose exec glpi php -i
+
+# List loaded extensions
+docker compose exec glpi php -m
+```
+
+### Running GLPI Console Commands
+
+The GLPI CLI console is available inside the container:
+
+```bash
+# Check database status
+docker compose exec glpi php bin/console db:check
+
+# Force a database update
+docker compose exec glpi php bin/console database:update
+
+# List available commands
+docker compose exec glpi php bin/console list
+```
+
+### Supported Database Engines
+
+| Engine | Tested Versions |
+|:-------|:----------------|
+| MySQL | 5.7, 8.0, 8.4 |
+| MariaDB | 10.4 — 11.8 |
+| Percona | 5.7, 8.0, 8.4 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,649 @@
+# Technical Architecture
+
+This document provides a deep technical reference for the GLPI Docker image internals: build process, runtime behavior, configuration files, process management, and security model.
+
+For usage instructions, see the [README](../README.md).
+For contributing and building locally, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Table of Contents
+
+- [Multi-Stage Build](#multi-stage-build)
+- [Runtime Entrypoint](#runtime-entrypoint)
+- [Process Management (Supervisor)](#process-management-supervisor)
+- [Scheduler System](#scheduler-system)
+- [Log Forwarding](#log-forwarding)
+- [Apache Configuration](#apache-configuration)
+- [PHP Configuration](#php-configuration)
+- [Security Model](#security-model)
+- [Volume Layout](#volume-layout)
+- [Environment Variable Reference](#environment-variable-reference)
+- [Build Argument Reference](#build-argument-reference)
+- [CI/CD Pipeline](#cicd-pipeline)
+- [Supporting Images](#supporting-images)
+
+---
+
+## Multi-Stage Build
+
+The Dockerfile (`glpi/Dockerfile`) uses three stages to minimize the final image size and separate build-time from runtime dependencies.
+
+### Stage 1: Downloader
+
+```
+Base: alpine
+Purpose: Resolve GLPI version and download source tarball
+```
+
+**Version resolution logic:**
+
+| Input | Behavior |
+|:------|:---------|
+| `latest` | Queries GitHub API (`/repos/glpi-project/glpi/releases/latest`) to resolve the latest stable tag |
+| Semver tag (e.g. `11.0.4`) | Downloads `https://github.com/glpi-project/glpi/archive/<tag>.tar.gz` |
+| Branch (e.g. `main`, `11.0/bugfixes`) | Same URL pattern — GitHub resolves branches to archives |
+| Commit SHA (40 chars) | Same URL pattern — GitHub resolves full or short SHAs |
+| `https://...` URL | Downloads directly from the given URL |
+
+**Output:** `/glpi.tar.gz`
+
+### Stage 2: Builder
+
+```
+Base: php:cli-alpine (configurable via BUILDER_IMAGE)
+Purpose: Install dependencies, compile assets, build GLPI
+```
+
+**System packages installed:**
+- `bash` — build script execution
+- `patch` — optional patching support
+- `gettext`, `perl` — locale compilation
+- `nodejs`, `npm` — frontend asset building
+- `git`, `unzip`, `curl` — Composer dependency resolution
+
+**PHP extensions installed:**
+- `intl` (required by GLPI console)
+
+**PHP configuration:**
+- `memory_limit = 512M` (build-time only)
+
+**Build process:**
+
+1. Source tarball extracted to `/usr/src/glpi`
+2. Ownership set to `www-data:www-data`
+3. Optional patches applied (from `GLPI_PATCH_URL`, space-separated URLs)
+4. `build_glpi.sh` executed as `www-data` (runs Composer install + npm build)
+
+**Patch application:**
+```bash
+# Each patch URL is fetched and applied with:
+curl --location "${PATCH}" | patch --strip=1
+```
+
+### Stage 3: Application
+
+```
+Base: php:apache (configurable via APP_IMAGE)
+Purpose: Final runtime image
+```
+
+**PHP extensions installed via apt + docker-php-ext-install:**
+
+| Extension | System Dependencies | Notes |
+|:----------|:-------------------|:------|
+| apcu | — | PECL install, `apc.enable=1` |
+| bz2 | libbz2-dev | |
+| exif | — | |
+| gd | libfreetype6-dev, libjpeg-dev, libpng-dev | `--with-freetype --with-jpeg` |
+| intl | libicu-dev | |
+| ldap | libldap2-dev | `--with-libdir=lib/x86_64-linux-gnu/` |
+| mysqli | — | |
+| bcmath | — | |
+| opcache | — | Skipped on PHP 8.5+ (built-in) |
+| redis | — | PECL install |
+| soap | libxml2-dev | |
+| zip | libzip-dev | |
+
+**System packages installed:**
+
+| Package | Purpose |
+|:--------|:--------|
+| supervisor | Process management (Apache + cron) |
+| libcap2-bin | `setcap` for non-root port binding |
+| acl | ACL management for shared volumes |
+| default-mysql-client | Database CLI tools |
+
+**Image configuration:**
+- PHP production config: `php.ini-production` symlinked
+- Apache `setcap cap_net_bind_service=+ep` on `/usr/sbin/apache2`
+- All scripts in `/opt/glpi/` set to executable
+- GLPI source copied from builder to `/var/www/glpi`
+- Volume directory created at `/var/glpi` (owned by `www-data`)
+
+---
+
+## Runtime Entrypoint
+
+**File:** `glpi/files/opt/glpi/entrypoint.sh`
+
+```bash
+#!/bin/bash
+set -e -u -o pipefail
+
+/opt/glpi/entrypoint/init-volumes-directories.sh
+/opt/glpi/entrypoint/forward-logs.sh
+/opt/glpi/entrypoint/wait-for-db.sh entrypoint
+/opt/glpi/entrypoint/install.sh
+
+exec "$@"
+```
+
+All scripts run sequentially. Failure in any script (`set -e`) stops the container.
+
+### init-volumes-directories.sh
+
+Creates the directory tree under `/var/glpi` if directories don't exist:
+
+**Root directories (write-permission checked):**
+- `${GLPI_CONFIG_DIR}` → `/var/glpi/config`
+- `${GLPI_VAR_DIR}` → `/var/glpi/files`
+- `${GLPI_MARKETPLACE_DIR}` → `/var/glpi/marketplace`
+- `${GLPI_LOG_DIR}` → `/var/glpi/logs`
+
+**Subdirectories (created under `GLPI_VAR_DIR`):**
+```
+_cache  _cron  _dumps  _graphs  _locales  _lock
+_pictures  _plugins  _rss  _sessions  _tmp  _uploads  _inventories
+```
+
+If any root directory is not writable, the script exits with an error message indicating the required UID.
+
+### wait-for-db.sh
+
+Accepts a caller name argument (used in log prefixes).
+
+**Skip condition:** If any of `GLPI_DB_HOST`, `GLPI_DB_PORT`, `GLPI_DB_NAME`, `GLPI_DB_USER`, or `GLPI_DB_PASSWORD` is unset or empty, the script exits successfully without waiting.
+
+**Connection test method:**
+```php
+$conn = @new mysqli('$GLPI_DB_HOST', '$GLPI_DB_USER', '$GLPI_DB_PASSWORD', '', (int) '$GLPI_DB_PORT');
+exit($conn->connect_error ? 1 : 0);
+```
+
+**Retry logic:**
+- Maximum 120 attempts
+- 1 second sleep between attempts
+- Exit code 1 on timeout
+
+### install.sh
+
+**Functions:**
+
+| Function | Description |
+|:---------|:------------|
+| `Install_GLPI()` | Runs `bin/console database:install` with DB credentials from env vars |
+| `Update_GLPI()` | Runs `bin/console database:update` |
+| `GLPI_Installed()` | Checks for `config_db.php` existence and runs `bin/console db:check` |
+
+**GLPI db:check exit codes:**
+
+| Code | Meaning | Treated as |
+|:-----|:--------|:-----------|
+| 0 | Everything OK | Installed |
+| 1-4 | SQL diff warnings (non-critical) | Installed |
+| 5 | Database connection error | Not installed |
+| 6 | Version not found | Not installed |
+| 7 | No tables found | Not installed |
+
+**Decision flow:**
+
+```
+IF database config incomplete:
+    → Force GLPI_SKIP_AUTOINSTALL=true and GLPI_SKIP_AUTOUPDATE=true
+
+IF GLPI not installed:
+    IF GLPI_SKIP_AUTOINSTALL=false:
+        → Run Install_GLPI()
+        → Display greeting with default credentials (glpi/glpi)
+
+IF GLPI already installed:
+    IF GLPI_SKIP_AUTOUPDATE=false:
+        → Run Update_GLPI()
+        → Display greeting (without credentials)
+```
+
+---
+
+## Process Management (Supervisor)
+
+**File:** `glpi/files/etc/supervisor/supervisord.conf`
+
+Supervisor runs as `www-data` in non-daemon mode (`nodaemon=true`), which is required for Docker containers.
+
+### Managed Processes
+
+| Program | Command | Auto-restart | Description |
+|:--------|:--------|:-------------|:------------|
+| `apache2` | `apache2-foreground` | yes | GLPI web server |
+| `glpi-cron` | `/opt/glpi/cron-worker.sh` | yes | Background task worker |
+
+All stdout/stderr is forwarded to `/dev/stdout` and `/dev/stderr` (Docker logging).
+
+### Custom Jobs Extension Point
+
+```ini
+[include]
+files = /etc/supervisor/conf.d/*.conf
+```
+
+Users can mount additional `.conf` files into `/etc/supervisor/conf.d/` to add custom supervised processes.
+
+---
+
+## Scheduler System
+
+**File:** `glpi/files/opt/glpi/scheduler.sh`
+
+Generic scheduling wrapper used by the cron worker and available for custom jobs.
+
+### Modes
+
+**Interval mode:**
+```
+scheduler.sh --interval <seconds> -- <command> [args...]
+```
+- Runs the command immediately on start
+- Sleeps for `<seconds>` between runs
+- Repeats indefinitely
+
+**Daily mode:**
+```
+scheduler.sh --daily <HH:MM> -- <command> [args...]
+```
+- Calculates sleep until the target time
+- If the target time has passed today, waits until tomorrow
+- Runs the command, then repeats daily
+
+### Options
+
+| Flag | Default | Description |
+|:-----|:--------|:------------|
+| `--interval <seconds>` | — | Interval between runs |
+| `--daily <HH:MM>` | — | Time of day to run (24h) |
+| `--name <name>` | `""` | Prefix for log messages: `[Name] ...` |
+| `--no-wait-for-db` | wait enabled | Skip database availability check before starting |
+
+### Database Waiting
+
+By default, the scheduler calls `wait-for-db.sh scheduler` before entering the main loop. This ensures the database is available before executing any GLPI commands.
+
+### Cron Worker
+
+**File:** `glpi/files/opt/glpi/cron-worker.sh`
+
+```bash
+# If cron is enabled:
+/opt/glpi/scheduler.sh --interval 60 --name "GLPI Cron" -- php /var/www/glpi/front/cron.php
+
+# If cron is disabled (GLPI_CRONTAB_ENABLED=0):
+tail -f /dev/null   # keeps supervisord happy
+```
+
+---
+
+## Log Forwarding
+
+**File:** `glpi/files/opt/glpi/entrypoint/forward-logs.sh`
+
+Creates GLPI log files if they don't exist, then tails them to container stdout/stderr using `/proc/1/fd/1` (stdout) and `/proc/1/fd/2` (stderr).
+
+| Log File | Destination | Content |
+|:---------|:------------|:--------|
+| `${GLPI_LOG_DIR}/event.log` | stdout | Application events |
+| `${GLPI_LOG_DIR}/cron.log` | stdout | Cron task execution |
+| `${GLPI_LOG_DIR}/mail.log` | stdout | Mail operations |
+| `${GLPI_LOG_DIR}/php-errors.log` | stderr | PHP errors |
+| `${GLPI_LOG_DIR}/sql-errors.log` | stderr | Database errors |
+| `${GLPI_LOG_DIR}/mail-errors.log` | stderr | Mail errors |
+| `${GLPI_LOG_DIR}/access-errors.log` | stderr | Access errors |
+
+Each `tail -F` runs as a background process. The `-F` flag handles log rotation (follows by name, not inode).
+
+---
+
+## Apache Configuration
+
+### Virtual Host
+
+**File:** `glpi/files/etc/apache2/sites-available/000-default.conf`
+
+```apache
+<VirtualHost *:80>
+    DocumentRoot /var/www/glpi/public
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    <Directory /var/www/glpi/public>
+        Require all granted
+        RewriteEngine On
+
+        # Preserve HTTP Authorization header (for Bearer tokens / API)
+        RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+        # Redirect all requests to GLPI router, unless file exists
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^(.*)$ index.php [QSA,L]
+    </Directory>
+</VirtualHost>
+```
+
+### Server Hardening
+
+**File:** `glpi/files/etc/apache2/conf-available/zzz-glpi.conf`
+
+```apache
+ServerName localhost
+ServerTokens Prod       # Only "Server: Apache" in headers (no version)
+ServerSignature Off      # No Apache signature in error pages
+```
+
+### Enabled Modules
+
+- `rewrite` — URL routing to `index.php`
+
+---
+
+## PHP Configuration
+
+**File:** `glpi/files/etc/php/conf.d/glpi.ini`
+
+```ini
+; Session cookies security
+session.cookie_httponly = on
+session.cookie_samesite = "Strict"
+
+; Do not expose PHP version
+expose_php = off
+
+; PHP session persistence config
+session.gc_probability = 1
+session.gc_divisor = 100
+session.gc_maxlifetime = 60480   ; ~16.8 hours, matches CronTask::cronSession
+```
+
+**Base configuration:** `php.ini-production` (symlinked during build)
+
+**APCu configuration:** `apc.enable=1` (written to `docker-php-ext-apcu.ini`)
+
+---
+
+## Security Model
+
+### Non-Root Execution
+
+The container runs entirely as `www-data` (UID 33). Root is only used during the image build phase.
+
+```dockerfile
+# Allow Apache to bind to port 80 without root
+RUN setcap cap_net_bind_service=+ep /usr/sbin/apache2
+
+# Switch to non-root user
+USER www-data
+```
+
+### Supervisor runs as www-data
+
+```ini
+[supervisord]
+user=www-data
+```
+
+### HTTP Security Headers
+
+| Mechanism | Configuration | Effect |
+|:----------|:-------------|:-------|
+| `ServerTokens Prod` | Apache | Only sends `Server: Apache` (no version) |
+| `ServerSignature Off` | Apache | No Apache footer in error pages |
+| `expose_php = off` | PHP | No `X-Powered-By: PHP/x.x.x` header |
+| `session.cookie_httponly = on` | PHP | Session cookies inaccessible to JavaScript |
+| `session.cookie_samesite = Strict` | PHP | Cookies only sent to same-origin requests |
+
+### Bearer Token Preservation
+
+The Apache rewrite rule explicitly preserves the `Authorization` header, which PHP-Apache would otherwise strip:
+
+```apache
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+```
+
+This is required for GLPI's REST API (Bearer token authentication).
+
+### File Permissions
+
+- Application source (`/var/www/glpi`): owned by `www-data`, read-only at runtime
+- Volume data (`/var/glpi`): owned by `www-data`, read-write
+- ACL tools (`acl` package) available for advanced permission management on shared volumes
+
+---
+
+## Volume Layout
+
+```
+/var/glpi/                           # Docker VOLUME
+├── config/                          # GLPI_CONFIG_DIR
+│   └── config_db.php                # Database credentials (created on install)
+├── files/                           # GLPI_VAR_DIR
+│   ├── _cache/                      # Symfony/GLPI cache
+│   ├── _cron/                       # Cron task state files
+│   ├── _dumps/                      # Database export dumps
+│   ├── _graphs/                     # Generated graph images
+│   ├── _locales/                    # Compiled translation files
+│   ├── _lock/                       # Application lock files
+│   ├── _pictures/                   # Uploaded profile pictures
+│   ├── _plugins/                    # Plugin working data
+│   ├── _rss/                        # RSS feed cache
+│   ├── _sessions/                   # PHP session files
+│   ├── _tmp/                        # Temporary files
+│   ├── _uploads/                    # User-uploaded documents
+│   └── _inventories/                # GLPI Agent inventory files
+├── marketplace/                     # GLPI_MARKETPLACE_DIR
+│   └── <plugin-name>/              # Plugins installed from GLPI marketplace
+└── logs/                            # GLPI_LOG_DIR
+    ├── event.log
+    ├── cron.log
+    ├── mail.log
+    ├── php-errors.log
+    ├── sql-errors.log
+    ├── mail-errors.log
+    └── access-errors.log
+```
+
+### Application Directory (not a volume)
+
+```
+/var/www/glpi/                       # WORKDIR, read-only at runtime
+├── public/                          # Apache DocumentRoot
+│   └── index.php                    # GLPI front controller
+├── bin/
+│   └── console                      # GLPI CLI tool
+├── front/
+│   └── cron.php                     # Cron entry point
+├── plugins/                         # Mountable for custom plugins
+└── ...                              # GLPI application files
+```
+
+---
+
+## Environment Variable Reference
+
+### Required for Auto-Install
+
+| Variable | Example | Description |
+|:---------|:--------|:------------|
+| `GLPI_DB_HOST` | `db` | Database hostname or IP |
+| `GLPI_DB_PORT` | `3306` | Database TCP port |
+| `GLPI_DB_NAME` | `glpi` | Database schema name |
+| `GLPI_DB_USER` | `glpi` | Database username |
+| `GLPI_DB_PASSWORD` | `secret` | Database password |
+
+### Optional Runtime
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `GLPI_SKIP_AUTOINSTALL` | `false` | Skip automatic `database:install` on first run |
+| `GLPI_SKIP_AUTOUPDATE` | `false` | Skip automatic `database:update` on restart |
+| `GLPI_CRONTAB_ENABLED` | `1` | `0` to disable the background cron worker |
+
+### Internal (set by Dockerfile)
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `GLPI_INSTALL_MODE` | `DOCKER` | Signals to GLPI that it runs in a container |
+| `GLPI_CONFIG_DIR` | `/var/glpi/config` | Configuration directory |
+| `GLPI_VAR_DIR` | `/var/glpi/files` | Data files directory |
+| `GLPI_LOG_DIR` | `/var/glpi/logs` | Log files directory |
+| `GLPI_MARKETPLACE_DIR` | `/var/glpi/marketplace` | Marketplace plugins directory |
+
+---
+
+## Build Argument Reference
+
+| Argument | Default | Description |
+|:---------|:--------|:------------|
+| `BUILDER_IMAGE` | `php:cli-alpine` | Base image for the builder stage |
+| `APP_IMAGE` | `php:apache` | Base image for the application stage |
+| `GLPI_VERSION` | `latest` | Version to build (tag, branch, commit, URL, or `latest`) |
+| `GLPI_CACHE_KEY` | `""` | Cache-busting key (used by CI to force rebuild) |
+| `GLPI_PATCH_URL` | `""` | Space-separated URLs of `.diff`/`.patch` files to apply |
+| `GLPI_MARKETPLACE_DIR` | `/var/glpi/marketplace` | Marketplace path. Use `/var/www/glpi/marketplace` for GLPI 10.x |
+
+### Build Examples
+
+```bash
+# Latest stable
+docker build glpi/
+
+# Specific version
+docker build --build-arg GLPI_VERSION=11.0.4 glpi/
+
+# Branch
+docker build --build-arg GLPI_VERSION=11.0/bugfixes glpi/
+
+# Commit
+docker build --build-arg GLPI_VERSION=2186bc6bd410d8bcb048637b3c0fb86b7e320c0a glpi/
+
+# Direct URL
+docker build --build-arg GLPI_VERSION=https://github.com/glpi-project/glpi/archive/2186bc6.tar.gz glpi/
+
+# With patches
+docker build \
+  --build-arg GLPI_VERSION=11.0.4 \
+  --build-arg "GLPI_PATCH_URL=https://example.com/fix1.diff https://example.com/fix2.diff" \
+  glpi/
+
+# Custom PHP version
+docker build --build-arg APP_IMAGE=php:8.3-apache glpi/
+
+# GLPI 10.x marketplace path
+docker build --build-arg GLPI_MARKETPLACE_DIR=/var/www/glpi/marketplace glpi/
+```
+
+---
+
+## CI/CD Pipeline
+
+### Main Workflow: `glpi.yml`
+
+**Triggers:**
+- `workflow_call` — reusable by the `glpi-project/glpi` repository
+- `workflow_dispatch` — manual builds
+- `push`/`pull_request` — on changes to `glpi/**`
+
+**Jobs:**
+
+```
+prepare → build (matrix: amd64, arm64) → merge-manifests
+```
+
+**1. prepare**
+- Resolves GLPI version to a commit SHA (for cache-busting)
+- Determines tag metadata: `is-latest`, `is-latest-major`
+- Validates semver format
+
+**2. build**
+- Matrix: `linux/amd64` (ubuntu-24.04), `linux/arm64` (ubuntu-24.04-arm)
+- Uses Docker Buildx with GHA cache
+- Outputs image digests for manifest merging
+
+**3. merge-manifests**
+- Runs only when `push=true`
+- Creates multi-arch manifests for Docker Hub and GHCR
+- Applies semantic versioning tags:
+  - `<version>` (e.g. `11.0.4`)
+  - `<major>` (e.g. `11`) — only for latest major
+  - `latest` — only for latest release
+
+### Registries
+
+| Registry | Image | Auth Secret |
+|:---------|:------|:------------|
+| Docker Hub | `glpi/glpi` | `DOCKER_HUB_USERNAME`, `DOCKER_HUB_TOKEN` |
+| GHCR | `ghcr.io/glpi-project/glpi` | `GHCR_USERNAME`, `GHCR_ACCESS_TOKEN` |
+
+### Cache Strategy
+
+- Backend: GitHub Actions cache
+- Scope: per-branch with fallback to `main`
+- Cache key includes `GLPI_CACHE_KEY` (commit SHA) for invalidation
+
+---
+
+## Supporting Images
+
+The repository also builds supporting images for CI/CD and development:
+
+### GitHub Actions Images
+
+| Image | Base | Purpose | PHP Versions |
+|:------|:-----|:--------|:-------------|
+| `githubactions-php` | php:fpm-alpine | PHP-FPM for tests | 7.4 — 8.5 |
+| `githubactions-php-apache` | php:apache | PHP-Apache for tests | 7.4 — 8.5 |
+| `githubactions-php-coverage` | php:8.0 | Code coverage with pcov | 8.0 |
+| `githubactions-glpi-apache` | glpi image | Pre-built GLPI for e2e | nightly |
+
+### Database Images
+
+| Image | Versions |
+|:------|:---------|
+| MariaDB | 10.4, 10.5, 10.6, 10.9, 10.10, 10.11, 11.0, 11.4, 11.8 |
+| MySQL | 5.7, 8.0, 8.4 |
+| Percona | 5.7, 8.0, 8.4 |
+
+Database images include performance-optimized configuration for testing:
+- Memory-based datadir (`/dev/shm/mysql`)
+- Tuned buffer pool and cache sizes
+- Disabled binary logging
+- MySQL 8.0+ authentication plugin compatibility
+
+### Service Images
+
+| Image | Purpose |
+|:------|:--------|
+| `githubactions-redis` | Redis with healthcheck |
+| `githubactions-memcached` | Memcached with netcat healthcheck |
+| `githubactions-openldap` | OpenLDAP (Alpine) for LDAP testing |
+| `githubactions-dovecot` | Dovecot mail server for email testing |
+
+### Development Environment
+
+| Image | Purpose |
+|:------|:--------|
+| `glpi-development-env` | Full dev environment with xdebug, nodejs, Cypress deps, Python tools |
+| `plugin-builder` | Plugin build utilities (Composer, npm, Python, gettext) |
+
+The development environment includes xdebug configured with:
+```ini
+xdebug.mode=develop,debug
+xdebug.start_with_request=trigger
+xdebug.client_host=host.docker.internal
+```


### PR DESCRIPTION
## Summary

- Rewrite README.md with expanded sections covering all aspects of the Docker image
- Add `docs/architecture.md` as a deep technical reference for contributors and advanced users
- Link the architecture doc from the README header

## README Changes

New sections added to the existing README:

- **Image Architecture** — Build stages, entrypoint flow, PHP extensions, Apache config, security features
- **Environment Variables** — Complete reference tables for database, installation, cron, and path variables
- **Volumes and Data Persistence** — Full directory tree, named volumes vs bind mounts, GLPI 10.x notes
- **Default PHP Settings** — Table of production settings applied by the image
- **Custom Apache Configuration** — Mounting and enabling custom configs
- **Managing Cron Tasks** — Dedicated cron container pattern for horizontal scaling
- **Reverse Proxy and HTTPS** — Nginx and Traefik examples
- **Upgrading** — Automatic/manual procedures with backup steps
- **Multi-Architecture Support** — Platforms, registries, and tags
- **Troubleshooting** — Logs, database, permissions, PHP config, console commands, supported engines

## New: `docs/architecture.md`

Technical reference covering:

- Multi-stage Dockerfile breakdown
- Entrypoint scripts (init-volumes, forward-logs, wait-for-db, install)
- Supervisor configuration and custom jobs extension
- Scheduler system internals
- Log forwarding mechanism
- Apache/PHP configuration details
- Security model (non-root, setcap, headers, session cookies)
- Volume layout with file descriptions
- Build argument reference with examples
- CI/CD pipeline architecture
- Supporting images catalog

## Test plan

- [x] All links in the summary/TOC resolve correctly
- [x] Code examples are accurate (verified against source files)
- [x] Environment variables match the Dockerfile and entrypoint scripts
- [x] Volume directory tree matches `init-volumes-directories.sh`
- [x] No references to unmerged features (Docker Secrets excluded, pending #276)

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)