### PR TITLE
Database ssl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ All five variables below are **required** for auto-install and auto-update to wo
 
 Database SSL/TLS configuration:
 
+> Only available for GLPI 11.0.7 and above.
+
 | Variable             | Default   | Description                                                 |
 |:---------------------|:----------|:------------------------------------------------------------|
 | `GLPI_DB_SSL`        | `false`   | Set to `true` to enable SSL/TLS for the database connection |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains build files for docker images available in [Github Cont
 - [Custom PHP configuration](#custom-php-configuration)
 - [Managing Cron tasks](#managing-cron-tasks)
 - [Adding custom Cron tasks](#adding-custom-cron-tasks)
+- [Environment variables](#environment-variables)
 - [Image Maintenance Policy](#image-maintenance-policy)
 
 ## How to use this image
@@ -158,15 +159,62 @@ By default, the image includes a background worker that executes GLPI cron tasks
 
 This is especially useful for horizontal scaling or Kubernetes deployments, where you might want a dedicated container for cron tasks while disabling it on Web or API nodes to avoid automatic tasks duplication.
 
-| Variable               | Default | Description                                                  |
-|:-----------------------|:--------|:-------------------------------------------------------------|
-| `GLPI_CRONTAB_ENABLED` | `1`     | Set to `1` to run the cron worker. Set to `0` to disable it. |
+See [environment variables section](#cron) for more details.
 
 ### Adding custom Cron tasks
 
 Since the container runs as the non-root `www-data` user, traditional cron is not available. Instead, this image provides a built-in scheduler script that supports interval-based and daily scheduled tasks through supervisord.
 
 See the [custom scheduled jobs documentation](docs/custom-cron-tasks.md) for usage examples.
+
+## Environment variables
+
+### Database
+
+All five variables below are **required** for auto-install and auto-update to work. If any is missing, both features are disabled and GLPI will present the web-based installation wizard instead.
+
+| Variable           | Example  | Description                     |
+|:-------------------|:---------|:--------------------------------|
+| `GLPI_DB_HOST`     | `db`     | Database hostname or IP address |
+| `GLPI_DB_PORT`     | `3306`   | Database TCP port               |
+| `GLPI_DB_NAME`     | `glpi`   | Database name                   |
+| `GLPI_DB_USER`     | `glpi`   | Database username               |
+| `GLPI_DB_PASSWORD` | `secret` | Database password               |
+
+Database SSL/TLS configuration:
+
+| Variable             | Default   | Description                                                 |
+|:---------------------|:----------|:------------------------------------------------------------|
+| `GLPI_DB_SSL`        | `false`   | Set to `true` to enable SSL/TLS for the database connection |
+| `GLPI_DB_SSL_CA`     | _(empty)_ | Path to the Certificate Authority (CA) certificate file     |
+| `GLPI_DB_SSL_CERT`   | _(empty)_ | Path to the client certificate file                         |
+| `GLPI_DB_SSL_KEY`    | _(empty)_ | Path to the client private key file                         |
+| `GLPI_DB_SSL_CAPATH` | _(empty)_ | Path to a directory containing trusted CA certificates      |
+| `GLPI_DB_SSL_CIPHER` | _(empty)_ | Allowed cipher(s) for the SSL connection                    |
+
+### Installation/Update
+
+| Variable                | Default | Description                                                        |
+|:------------------------|:--------|:-------------------------------------------------------------------|
+| `GLPI_SKIP_AUTOINSTALL` | `false` | Set to `true` to skip automatic database installation on first run |
+| `GLPI_SKIP_AUTOUPDATE`  | `false` | Set to `true` to skip automatic database schema updates on restart |
+
+### Cron
+
+| Variable               | Default | Description                                      |
+|:-----------------------|:--------|:-------------------------------------------------|
+| `GLPI_CRONTAB_ENABLED` | `1`     | Set to `0` to disable the background cron worker |
+
+### Path configuration
+
+These are preconfigured and generally do not need to be changed.
+
+| Variable               | Default                 | Description                  |
+|:-----------------------|:------------------------|:-----------------------------|
+| `GLPI_CONFIG_DIR`      | `/var/glpi/config`      | Configuration directory      |
+| `GLPI_VAR_DIR`         | `/var/glpi/files`       | Application data directory   |
+| `GLPI_LOG_DIR`         | `/var/glpi/logs`        | Log files directory          |
+| `GLPI_MARKETPLACE_DIR` | `/var/glpi/marketplace` | Plugin marketplace directory |
 
 ## Image Maintenance Policy
 Image maintenance is run and hosted on the GLPI project under a scheduled GitHub workflow.

--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache curl jq
 RUN set -ex; \
     INPUT="${GLPI_VERSION}"; \
     # If input starts with https://, use it as-is \
-    if echo "$INPUT" | grep --quiet '^https://'; then \
+    if echo "$INPUT" | grep -q '^https://'; then \
       URL="$INPUT"; \
     else \
       VERSION="$INPUT"; \
@@ -45,7 +45,7 @@ RUN set -ex; \
       URL="https://github.com/glpi-project/glpi/archive/${VERSION}.tar.gz"; \
     fi; \
     echo "Downloading GLPI from $URL"; \
-    curl --location "$URL" --output /glpi.tar.gz
+    curl --fail --location "$URL" --output /glpi.tar.gz
 
 #####
 # Builder image

--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -231,7 +231,13 @@ ENV \
   GLPI_VAR_DIR=/var/glpi/files \
   GLPI_LOG_DIR=/var/glpi/logs \
   GLPI_SKIP_AUTOINSTALL=false \
-  GLPI_SKIP_AUTOUPDATE=false
+  GLPI_SKIP_AUTOUPDATE=false \
+  GLPI_DB_SSL=false \
+  GLPI_DB_SSL_CA="" \
+  GLPI_DB_SSL_CERT="" \
+  GLPI_DB_SSL_KEY="" \
+  GLPI_DB_SSL_CAPATH="" \
+  GLPI_DB_SSL_CIPHER=""
 
 # Pass the execution to the www-data user
 USER www-data

--- a/glpi/Dockerfile
+++ b/glpi/Dockerfile
@@ -231,13 +231,7 @@ ENV \
   GLPI_VAR_DIR=/var/glpi/files \
   GLPI_LOG_DIR=/var/glpi/logs \
   GLPI_SKIP_AUTOINSTALL=false \
-  GLPI_SKIP_AUTOUPDATE=false \
-  GLPI_DB_SSL=false \
-  GLPI_DB_SSL_CA="" \
-  GLPI_DB_SSL_CERT="" \
-  GLPI_DB_SSL_KEY="" \
-  GLPI_DB_SSL_CAPATH="" \
-  GLPI_DB_SSL_CIPHER=""
+  GLPI_SKIP_AUTOUPDATE=false
 
 # Pass the execution to the www-data user
 USER www-data

--- a/glpi/files/opt/glpi/entrypoint/install.sh
+++ b/glpi/files/opt/glpi/entrypoint/install.sh
@@ -2,12 +2,23 @@
 set -e -u -o pipefail
 
 Install_GLPI() {
+    ssl_args=()
+    if [ "${GLPI_DB_SSL:-false}" = "true" ]; then
+        ssl_args+=(--db-ssl)
+        [ -n "${GLPI_DB_SSL_CA:-}"     ] && ssl_args+=(--db-ssl-ca="$GLPI_DB_SSL_CA")
+        [ -n "${GLPI_DB_SSL_CERT:-}"   ] && ssl_args+=(--db-ssl-cert="$GLPI_DB_SSL_CERT")
+        [ -n "${GLPI_DB_SSL_KEY:-}"    ] && ssl_args+=(--db-ssl-key="$GLPI_DB_SSL_KEY")
+        [ -n "${GLPI_DB_SSL_CAPATH:-}" ] && ssl_args+=(--db-ssl-capath="$GLPI_DB_SSL_CAPATH")
+        [ -n "${GLPI_DB_SSL_CIPHER:-}" ] && ssl_args+=(--db-ssl-cipher="$GLPI_DB_SSL_CIPHER")
+    fi
+
     bin/console database:install \
         --db-host="$GLPI_DB_HOST" \
         --db-port="$GLPI_DB_PORT" \
         --db-name="$GLPI_DB_NAME" \
         --db-user="$GLPI_DB_USER" \
         --db-password="$GLPI_DB_PASSWORD" \
+        "${ssl_args[@]}" \
         --no-interaction --quiet
 }
 

--- a/glpi/files/opt/glpi/entrypoint/wait-for-db.sh
+++ b/glpi/files/opt/glpi/entrypoint/wait-for-db.sh
@@ -20,13 +20,13 @@ until [ $attempts_left -eq 0 ]; do
     # Try a simple database connection check using PHP mysqli
     if php -r "
         \$conn = @new mysqli();
-        if ('$GLPI_DB_SSL' === 'true') {
+        if ('${GLPI_DB_SSL:-false}' === 'true') {
             \$conn->ssl_set(
-                '$GLPI_DB_SSL_KEY'    ?: null,
-                '$GLPI_DB_SSL_CERT'   ?: null,
-                '$GLPI_DB_SSL_CA'     ?: null,
-                '$GLPI_DB_SSL_CAPATH' ?: null,
-                '$GLPI_DB_SSL_CIPHER' ?: null
+                '${GLPI_DB_SSL_KEY:-}'    ?: null,
+                '${GLPI_DB_SSL_CERT:-}'   ?: null,
+                '${GLPI_DB_SSL_CA:-}'     ?: null,
+                '${GLPI_DB_SSL_CAPATH:-}' ?: null,
+                '${GLPI_DB_SSL_CIPHER:-}' ?: null
             );
         }
         @\$conn->real_connect('$GLPI_DB_HOST', '$GLPI_DB_USER', '$GLPI_DB_PASSWORD', '', (int) '$GLPI_DB_PORT');

--- a/glpi/files/opt/glpi/entrypoint/wait-for-db.sh
+++ b/glpi/files/opt/glpi/entrypoint/wait-for-db.sh
@@ -19,7 +19,17 @@ attempts_left=120
 until [ $attempts_left -eq 0 ]; do
     # Try a simple database connection check using PHP mysqli
     if php -r "
-        \$conn = @new mysqli('$GLPI_DB_HOST', '$GLPI_DB_USER', '$GLPI_DB_PASSWORD', '', (int) '$GLPI_DB_PORT');
+        \$conn = @new mysqli();
+        if ('$GLPI_DB_SSL' === 'true') {
+            \$conn->ssl_set(
+                '$GLPI_DB_SSL_KEY'    ?: null,
+                '$GLPI_DB_SSL_CERT'   ?: null,
+                '$GLPI_DB_SSL_CA'     ?: null,
+                '$GLPI_DB_SSL_CAPATH' ?: null,
+                '$GLPI_DB_SSL_CIPHER' ?: null
+            );
+        }
+        @\$conn->real_connect('$GLPI_DB_HOST', '$GLPI_DB_USER', '$GLPI_DB_PASSWORD', '', (int) '$GLPI_DB_PORT');
         exit(\$conn->connect_error ? 1 : 0);
     " 2>/dev/null; then
         echo "[$caller] The database is now ready and reachable."


### PR DESCRIPTION
Add SSL support for database.

Also add some env var documentation

Closes https://github.com/glpi-project/docker-images/issues/220

Needs : [glpi-project/glpi#23779](https://github.com/glpi-project/glpi/pull/23779) to be working correctly

## Docker-compose for testing

`docker compose -f docker-compose.ssl-test.yml up`

```yaml
name: glpi_docker_dev_ssl

services:
  gen-certs:
    image: alpine
    volumes:
      - ssl_certs:/ssl
    command:
      - sh
      - -c
      - |
        [ -f /ssl/ca-cert.pem ] && echo "Certificates already exist, skipping." && exit 0
        apk add --quiet openssl

        openssl genrsa 2048 > /ssl/ca-key.pem
        openssl req -new -x509 -nodes -days 3650 \
          -key /ssl/ca-key.pem -out /ssl/ca-cert.pem \
          -subj "/CN=GLPI Test CA"

        openssl req -newkey rsa:2048 -days 3650 -nodes \
          -keyout /ssl/server-key.pem -out /ssl/server-req.pem \
          -subj "/CN=db"
        openssl x509 -req -in /ssl/server-req.pem -days 3650 \
          -CA /ssl/ca-cert.pem -CAkey /ssl/ca-key.pem \
          -set_serial 01 -out /ssl/server-cert.pem

        openssl req -newkey rsa:2048 -days 3650 -nodes \
          -keyout /ssl/client-key.pem -out /ssl/client-req.pem \
          -subj "/CN=glpi"
        openssl x509 -req -in /ssl/client-req.pem -days 3650 \
          -CA /ssl/ca-cert.pem -CAkey /ssl/ca-key.pem \
          -set_serial 02 -out /ssl/client-cert.pem

        rm /ssl/server-req.pem /ssl/client-req.pem
        chmod 644 /ssl/*.pem
        echo "Certificates generated."

  glpi:
    build:
      context: ./glpi
      args:
        GLPI_VERSION: https://github.com/froozeify/glpi/archive/refs/heads/11.0/database-ssl-support.tar.gz
        GLPI_PATCH_URL: ''
    restart: "no"
    volumes:
      - glpi_data:/var/glpi
      - ssl_certs:/ssl:ro
    environment:
      - GLPI_DB_HOST=db
      - GLPI_DB_NAME=glpi
      - GLPI_DB_USER=glpi
      - GLPI_DB_PASSWORD=glpi
      - GLPI_DB_PORT=3306
      - GLPI_INSTALL_MODE=DOCKER
      - GLPI_DB_SSL=true
      - GLPI_DB_SSL_CA=/ssl/ca-cert.pem
      - GLPI_DB_SSL_CERT=/ssl/client-cert.pem
      - GLPI_DB_SSL_KEY=/ssl/client-key.pem
    ports:
      - "8080:80"
    depends_on:
      gen-certs:
        condition: service_completed_successfully
      db:
        condition: service_started

  db:
    image: mariadb:latest
    restart: "no"
    command:
      - --ssl-ca=/ssl/ca-cert.pem
      - --ssl-cert=/ssl/server-cert.pem
      - --ssl-key=/ssl/server-key.pem
    environment:
      MYSQL_ROOT_PASSWORD: root
      MYSQL_DATABASE: glpi
      MYSQL_USER: glpi
      MYSQL_PASSWORD: glpi
    volumes:
      - db_data:/var/lib/mysql
      - ssl_certs:/ssl:ro
    depends_on:
      gen-certs:
        condition: service_completed_successfully

volumes:
  glpi_data:
  db_data:
  ssl_certs:

```