### PR TITLE
Switch to node v24 LTS

### DIFF
--- a/githubactions-php-apache/Dockerfile
+++ b/githubactions-php-apache/Dockerfile
@@ -101,7 +101,7 @@ RUN \
   && apt install --assume-yes --no-install-recommends --quiet gnupg \
   && mkdir -p /etc/apt/keyrings \
   && curl --fail --silent --show-error --location https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor --output /etc/apt/keyrings/nodesource.gpg \
-  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
   && apt update \
   && apt install --assume-yes --no-install-recommends --quiet nodejs \
   \

--- a/githubactions-php/Dockerfile
+++ b/githubactions-php/Dockerfile
@@ -93,7 +93,7 @@ RUN \
   && apt install --assume-yes --no-install-recommends --quiet gnupg \
   && mkdir -p /etc/apt/keyrings \
   && curl --fail --silent --show-error --location https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor --output /etc/apt/keyrings/nodesource.gpg \
-  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
   && apt update \
   && apt install --assume-yes --no-install-recommends --quiet nodejs \
   \

--- a/glpi-development-env/Dockerfile
+++ b/glpi-development-env/Dockerfile
@@ -102,7 +102,7 @@ RUN apt update \
   && apt install --assume-yes --no-install-recommends --quiet gnupg \
   && mkdir -p /etc/apt/keyrings \
   && curl --fail --silent --show-error --location https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor --output /etc/apt/keyrings/nodesource.gpg \
-  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
   && apt update \
   && apt install --assume-yes --no-install-recommends --quiet nodejs \
   \


### PR DESCRIPTION
This LTS version is now available in all major linux distributions.