### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository contains build files for docker images available in [Github Cont
 - [How to use this image](#how-to-use-this-image)
   - [via docker compose](#via-docker-compose)
   - [via Podman](#via-podman)
+  - [via Sealos](#via-sealos)
 - [Timezones support](#timezones-support)
 - [Volumes](#volumes)
 - [Custom PHP configuration](#custom-php-configuration)
@@ -89,6 +90,14 @@ To run commands on a running container:
 ```bash
 podman exec -it <glpi_container_id> /var/www/glpi/bin/console database:enable_timezones
 ```
+
+### via [Sealos](https://sealos.io)
+
+Deploy GLPI with a dedicated MySQL database, persistent storage, and HTTPS using the Sealos template:
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/glpi)
+
+Choose an administrator password during deployment, then sign in with the username `glpi`.
 
 ### Timezones support
 


### PR DESCRIPTION
## Summary

This PR adds a Sealos deployment option to the README.

It adds:
- a table-of-contents entry
- a short deployment section with a Deploy on Sealos button
- the administrator username and password setup note

## Why

This gives Sealos users a one-click deployment path. The image, application code, and default installation flow remain unchanged.

## Validation

- Sealos template: https://sealos.io/products/app-store/glpi
- Template source: https://github.com/labring-actions/templates/tree/kb-0.9/template/glpi
- App image: `glpi/glpi:11.0.8`
- Tested deployment: yes, on 2026-08-14
- Smoke test: administrator login and Computers/Tickets navigation passed
- Stability: Ready with zero restarts during the validation window
- Persistence: `/var/glpi` and the dedicated MySQL database use persistent volumes
- Required input: the administrator password is entered during deployment; database credentials are provisioned automatically
- Documentation checks: `git diff --check` passed, GitHub Markdown rendering passed, and both Sealos links returned HTTP 200

## Maintenance

I can help maintain the Sealos deployment path and follow up if the template or documentation needs updates. The versioned template remains in the Sealos catalog repository, keeping this contribution docs-only.

## AI usage

OpenAI Codex was used to inspect contribution guidance, draft the README wording, and run documentation checks. I reviewed the final diff and deployment evidence.